### PR TITLE
Load libv8 with a version requirement in extconf.rb

### DIFF
--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -1,4 +1,5 @@
 require 'mkmf'
+gem 'libv8', '~> 8.4.255' # Should match the version requirement in mini_racer.gemspec
 require 'libv8'
 
 IS_DARWIN = RUBY_PLATFORM =~ /darwin/

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "m"
 
-  spec.add_dependency 'libv8', '~> 8.4.255'
+  spec.add_dependency 'libv8', '~> 8.4.255' # Make sure to update the version requirement in mini_racer_extension/extconfig.rb
   spec.require_paths = ["lib", "ext"]
 
   spec.extensions = ["ext/mini_racer_extension/extconf.rb"]


### PR DESCRIPTION
I'm not 100% certain yet, but I think the way mini_racer require `libv8` in `extconf.rb` load the most recent available libv8, which can cause compile errors on downgrades.

### Step to reproduce

from a clean system (e.g. fresh docker container)

```ruby
gem 'mini_racer', '0.3.1', require: false
```

```
bundle install # works fine
```

```ruby
gem 'libv8', '< 8'
gem 'mini_racer', '0.2.15', require: false
```

```
bundle install
....

In file included from mini_racer_extension.cc:5:
/app/vendor/gems/ruby/2.7.0/gems/libv8-8.4.255.0-x86_64-linux/vendor/v8/include/v8.h:3711:43: note: candidate: ‘v8::MaybeLocal<v8::Value> v8::Object::Get(v8::Local<v8::Context>, v8::Local<v8::Value>)’
   V8_WARN_UNUSED_RESULT MaybeLocal<Value> Get(Local<Context> context,
                                           ^~~
/app/vendor/gems/ruby/2.7.0/gems/libv8-8.4.255.0-x86_64-linux/vendor/v8/include/v8.h:3711:43: note:   candidate expects 2 arguments, 1 provided
/app/vendor/gems/ruby/2.7.0/gems/libv8-8.4.255.0-x86_64-linux/vendor/v8/include/v8.h:3714:43: note: candidate: ‘v8::MaybeLocal<v8::Value> v8::Object::Get(v8::Local<v8::Context>, uint32_t)’
   V8_WARN_UNUSED_RESULT MaybeLocal<Value> Get(Local<Context> context,
 
```

Notice how I ask for `libv8 < 8`, but the compiler error is against `8.4.x`. 

This did bite us several times last week as we were trying to upgrade, but had to revert. After each revert we had to flush the bundler cache.

It's too late for already published version, but going forward I think it might help to load `libv8` from `extconf.rb` with `gem 'libv8', '<version_spec>'`.