### PR TITLE
Isolate v8 symbols

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+/.bundle/
+/.yardoc
+Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+lib/mini_racer_extension.so
+lib/mini_racer_loader.so
+*.bundle

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ Gemfile.lock
 /spec/reports/
 /tmp/
 lib/mini_racer_extension.so
+lib/mini_racer_loader.so
 *.bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+ARG RUBY_VERSION=2.7
+FROM ruby:${RUBY_VERSION}
+
+# without this `COPY .git`, we get the following error:
+#   fatal: not a git repository (or any of the parent directories): .git
+# but with it we need the full gem just to compile the extension because
+# of gemspec's `git --ls-files`
+# COPY .git /code/.git
+COPY Gemfile mini_racer.gemspec /code/
+COPY lib/mini_racer/version.rb /code/lib/mini_racer/version.rb
+WORKDIR /code
+RUN bundle install
+
+COPY Rakefile /code/
+COPY ext /code/ext/
+RUN bundle exec rake compile
+
+COPY . /code/
+CMD bundle exec irb -rmini_racer

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ end
 task :default => [:compile, :test]
 
 gem = Gem::Specification.load( File.dirname(__FILE__) + '/mini_racer.gemspec' )
+Rake::ExtensionTask.new( 'mini_racer_loader', gem )
 Rake::ExtensionTask.new( 'mini_racer_extension', gem )
 
 

--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -14,6 +14,7 @@ $CPPFLAGS += " -fPIC" unless $CPPFLAGS.split.include? "-rdynamic" or IS_DARWIN
 $CPPFLAGS += " -std=c++0x"
 $CPPFLAGS += " -fpermissive"
 $CPPFLAGS += " -DV8_COMPRESS_POINTERS"
+$CPPFLAGS += " -fvisibility=hidden "
 
 $CPPFLAGS += " -Wno-reserved-user-defined-literal" if IS_DARWIN
 

--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -1658,7 +1658,7 @@ static void set_ruby_exiting(VALUE value) {
 
 extern "C" {
 
-    void Init_mini_racer_extension ( void )
+    __attribute__((visibility("default"))) void Init_mini_racer_extension ( void )
     {
         VALUE rb_mMiniRacer = rb_define_module("MiniRacer");
         rb_cContext = rb_define_class_under(rb_mMiniRacer, "Context", rb_cObject);

--- a/ext/mini_racer_loader/extconf.rb
+++ b/ext/mini_racer_loader/extconf.rb
@@ -1,0 +1,8 @@
+require 'mkmf'
+
+extension_name = 'mini_racer_loader'
+dir_config extension_name
+
+$CPPFLAGS += " -fvisibility=hidden "
+
+create_makefile extension_name

--- a/ext/mini_racer_loader/mini_racer_loader.c
+++ b/ext/mini_racer_loader/mini_racer_loader.c
@@ -1,0 +1,123 @@
+#include <ruby.h>
+#include <dlfcn.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+// Load a Ruby extension like Ruby does, only with flags that:
+// a) hide symbols from other extensions (RTLD_LOCAL)
+// b) bind symbols tightly (RTLD_DEEPBIND, when available)
+
+void Init_mini_racer_loader(void);
+
+static void *_dln_load(const char *file);
+
+static VALUE _load_shared_lib(VALUE self, volatile VALUE fname)
+{
+    (void) self;
+
+    // check that path is not tainted
+    SafeStringValue(fname);
+
+    FilePathValue(fname);
+    VALUE path = rb_str_encode_ospath(fname);
+
+    char *loc = StringValueCStr(path);
+    void *handle = _dln_load(loc);
+
+    return handle ? Qtrue : Qfalse;
+}
+
+// adapted from Ruby's dln.c
+#define INIT_FUNC_PREFIX ((char[]) {'I', 'n', 'i', 't', '_'})
+#define INIT_FUNCNAME(buf, file) do { \
+    const char *base = (file); \
+    const size_t flen = _init_funcname(&base); \
+    const size_t plen = sizeof(INIT_FUNC_PREFIX); \
+    char *const tmp = ALLOCA_N(char, plen + flen + 1); \
+    memcpy(tmp, INIT_FUNC_PREFIX, plen); \
+    memcpy(tmp+plen, base, flen); \
+    tmp[plen+flen] = '\0'; \
+    *(buf) = tmp; \
+} while(0)
+
+// adapted from Ruby's dln.c
+static size_t _init_funcname(const char **file)
+{
+    const char *p = *file,
+               *base,
+               *dot = NULL;
+
+    for (base = p; *p; p++) { /* Find position of last '/' */
+        if (*p == '.' && !dot) {
+            dot = p;
+        }
+        if (*p == '/') {
+            base = p + 1;
+            dot = NULL;
+        }
+    }
+    *file = base;
+    return (uintptr_t) ((dot ? dot : p) - base);
+}
+
+// adapted from Ruby's dln.c
+static void *_dln_load(const char *file)
+{
+    char *buf;
+    const char *error;
+#define DLN_ERROR() (error = dlerror(), strcpy(ALLOCA_N(char, strlen(error) + 1), error))
+
+    void *handle;
+    void (*init_fct)(void);
+
+    INIT_FUNCNAME(&buf, file);
+
+#ifndef RTLD_DEEPBIND
+# define RTLD_DEEPBIND 0
+#endif
+    /* Load file */
+    if ((handle = dlopen(file, RTLD_NOW|RTLD_LOCAL|RTLD_DEEPBIND)) == NULL) {
+        DLN_ERROR();
+        goto failed;
+    }
+#if defined(RUBY_EXPORT)
+    {
+        static const char incompatible[] = "incompatible library version";
+        void *ex = dlsym(handle, "ruby_xmalloc");
+        if (ex && ex != (void *) &ruby_xmalloc) {
+
+# if defined __APPLE__
+            /* dlclose() segfaults */
+            rb_fatal("%s - %s", incompatible, file);
+# else
+            dlclose(handle);
+            error = incompatible;
+            goto failed;
+#endif
+        }
+    }
+# endif
+
+    init_fct = (void (*)(void)) dlsym(handle, buf);
+    if (init_fct == NULL) {
+        error = DLN_ERROR();
+        dlclose(handle);
+        goto failed;
+    }
+
+    /* Call the init code */
+    (*init_fct)();
+
+    return handle;
+
+failed:
+    rb_raise(rb_eLoadError, "%s", error);
+}
+
+__attribute__((visibility("default"))) void Init_mini_racer_loader()
+{
+    VALUE mSqreen = rb_define_module("MiniRacer");
+    VALUE mPrvExtLoader = rb_define_module_under(mSqreen, "Loader");
+    rb_define_singleton_method(mPrvExtLoader, "load", _load_shared_lib, 1);
+}

--- a/ext/mini_racer_loader/mini_racer_loader.c
+++ b/ext/mini_racer_loader/mini_racer_loader.c
@@ -77,7 +77,7 @@ static void *_dln_load(const char *file)
 # define RTLD_DEEPBIND 0
 #endif
     /* Load file */
-    if ((handle = dlopen(file, RTLD_NOW|RTLD_LOCAL|RTLD_DEEPBIND)) == NULL) {
+    if ((handle = dlopen(file, RTLD_LAZY|RTLD_LOCAL|RTLD_DEEPBIND)) == NULL) {
         DLN_ERROR();
         goto failed;
     }
@@ -117,7 +117,7 @@ failed:
 
 __attribute__((visibility("default"))) void Init_mini_racer_loader()
 {
-    VALUE mSqreen = rb_define_module("MiniRacer");
-    VALUE mPrvExtLoader = rb_define_module_under(mSqreen, "Loader");
-    rb_define_singleton_method(mPrvExtLoader, "load", _load_shared_lib, 1);
+    VALUE mMiniRacer = rb_define_module("MiniRacer");
+    VALUE mLoader = rb_define_module_under(mMiniRacer, "Loader");
+    rb_define_singleton_method(mLoader, "load", _load_shared_lib, 1);
 }

--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -1,5 +1,12 @@
 require "mini_racer/version"
-require "mini_racer_extension"
+require "mini_racer_loader"
+
+ext_filename = "mini_racer_extension.#{RbConfig::CONFIG['DLEXT']}"
+ext_path = $LOAD_PATH.map { |p| (Pathname.new(p) + ext_filename) }.find { |p| p.file? }
+
+raise LoadError, "Could not find #{name}" unless ext_path
+MiniRacer::Loader.load(ext_path.to_s)
+
 require "thread"
 require "json"
 

--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -1,11 +1,14 @@
 require "mini_racer/version"
 require "mini_racer_loader"
+require "pathname"
 
 ext_filename = "mini_racer_extension.#{RbConfig::CONFIG['DLEXT']}"
-ext_path = $LOAD_PATH.map { |p| (Pathname.new(p) + ext_filename) }.find { |p| p.file? }
+ext_path = Gem.loaded_specs['mini_racer'].require_paths
+  .map { |p| (p = Pathname.new(p)).absolute? ? p : Pathname.new(__dir__).parent + p }
+ext_found = ext_path.map { |p| p + ext_filename }.find { |p| p.file? }
 
-raise LoadError, "Could not find #{name}" unless ext_path
-MiniRacer::Loader.load(ext_path.to_s)
+raise LoadError, "Could not find #{ext_filename} in #{ext_path.map(&:to_s)}" unless ext_found
+MiniRacer::Loader.load(ext_found.to_s)
 
 require "thread"
 require "json"

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'libv8', MiniRacer::LIBV8_VERSION
   spec.require_paths = ["lib", "ext"]
 
-  spec.extensions = ["ext/mini_racer_extension/extconf.rb"]
+  spec.extensions = ["ext/mini_racer_loader/extconf.rb", "ext/mini_racer_extension/extconf.rb"]
 
   spec.required_ruby_version = '>= 2.3'
 end


### PR DESCRIPTION
Hello!

We identified an issue happening when two extensions are built with different V8 versions, then loaded at the same time.

In an ideal world, all extensions would be built with `-fvisibility=hidden`, only exposing relevant symbols and avoiding clases, unfortunately that is not the case.

Indeed the libv8 gem does not build its static library with `-fvisibility=hidden`. The result is that when this static library is linked into a Ruby extension (IOW a dynamic library), V8 symbols are global, irrespective of passing `-fvisibility=hidden` when building the extension.

Additionally, Ruby doesn't really make an effort to load its extensions in isolated ways, resulting in the default of globally available symbols.

As a result, the second extension being loaded will resolve some of its V8 symbols to the first ones that were loaded.

To combat this, within Sqreen's fork of MiniRacer, we created a small wrapper that takes in charge loading the extension more privately by:

- enforcing all symbols to be local (via `RTLD_LOCAL`), preventing other libs to pick its symbols up
- attempting to enforce binding to local symbols first (via `RTLD_DEEPBIND`), preventing this lib to pick others symbols

Unfortunately, the latter is not always available, resulting in MiniRacer's V8 symbols being picked up by other libraries, even when they use `RTLD_LOCAL` (which only controls things one way). In that case we are left with no option.

This PR attempts to make MiniRacer a good citizen in two ways:

- first commit: compile with `-fvisibility=hidden` to hide any irrelevant `mini_racer_extension` symbols, and be ready if/when `libv8_monolith.a` is compiled with it too.
- second commit: hide V8 symbols from `libv8_monolith.a` that wasn't built with `-fvisibility=hidden`.

Considered alternatives
- linker version scripts to hide symbols, but it's only supported by GCC's `ld`
- `-exported_symbols_list` and `-unexported_symbols_list`, but it needs exhaustive generation of symbols to hide and show. Possible, but calling into `nm libv8_monolith.a` and parsing the output to generate the list could be unreliable.
- leveraging gem dependencies to ensure the same `libv8` version *and* build: unfortunately this does not mean a given lib wasn't built with a different v8, unless all gems pin their `libv8` versions *exactly* in their `gemspec` (this particular one stumped us for a long time)

Excerpt of `mini_racer_extension.bundle` symbol table (`T` means global, `t` means local`):

```
$ nm -C lib/mini_racer_extension.bundle | grep ' T' | head
0000000000003ce0 T _Init_mini_racer_extension
00000000001544b0 T _v8_internal_Get_Object(void*)
0000000000154870 T _v8_internal_Node_Print(void*)
0000000000154550 T _v8_internal_Print_Code(void*)
00000000001544f0 T _v8_internal_Print_Object(void*)
00000000001547c0 T _v8_internal_Print_StackTrace()
0000000000154800 T _v8_internal_Print_TransitionTree(void*)
0000000000154730 T _v8_internal_Print_LayoutDescriptor(void*)
000000000000f260 T V8_Fatal(char const*, ...)
000000000000f3b0 T V8_Dcheck(char const*, int, char const*)
```

Excerpt of a stack trace where code jumps from one lib to the other *within libv8*:

```
-- C level backtrace information -------------------------------------------
/Users/lloeki/.rubies/ruby-2.7.1/bin/ruby(rb_vm_bugreport+0x96) [0x106ebf616]
/Users/lloeki/.rubies/ruby-2.7.1/bin/ruby(rb_bug_for_fatal_signal+0x1d0) [0x106cf9270]
/Users/lloeki/.rubies/ruby-2.7.1/bin/ruby(sigsegv+0x5b) [0x106e22c4b]
/usr/lib/system/libsystem_platform.dylib(_sigtramp+0x1d) [0x7fff7248c5fd]
/Users/lloeki/.gem/ruby/2.7.1/gems/mini_racer-0.3.1/lib/mini_racer_extension.bundle(_ZN2v88internal12_GLOBAL__N_123GetPageTableInitializerEv+0x25) [0x10bade405]
/Users/lloeki/.gem/ruby/2.7.1/gems/mini_racer-0.3.1/lib/mini_racer_extension.bundle(0x10badea39) [0x10badea39]
/Users/lloeki/.gem/ruby/2.7.1/gems/mini_racer-0.3.1/lib/mini_racer_extension.bundle(0x10b77b3b6) [0x10b77b3b6]
/Users/lloeki/.gem/ruby/2.7.1/gems/mini_racer-0.3.1/lib/mini_racer_extension.bundle(0x10b77bc5e) [0x10b77bc5e]
/Users/lloeki/Workspace/github.com/sqreen/mini_racer/lib/sq_mini_racer_extension.bundle(_ZN2v88internal9SemiSpace6CommitEv+0x7a) [0x10d81df5a]
/Users/lloeki/Workspace/github.com/sqreen/mini_racer/lib/sq_mini_racer_extension.bundle(0x10d81de76) [0x10d81de76]
/Users/lloeki/Workspace/github.com/sqreen/mini_racer/lib/sq_mini_racer_extension.bundle(0x10d7a35ef) [0x10d7a35ef]
/Users/lloeki/Workspace/github.com/sqreen/mini_racer/lib/sq_mini_racer_extension.bundle(0x10d74cf00) [0x10d74cf00]
/Users/lloeki/Workspace/github.com/sqreen/mini_racer/lib/sq_mini_racer_extension.bundle(0x10d74c9fd) [0x10d74c9fd]
/Users/lloeki/Workspace/github.com/sqreen/mini_racer/lib/sq_mini_racer_extension.bundle(0x10d5e78fb) [0x10d5e78fb]
/Users/lloeki/Workspace/github.com/sqreen/mini_racer/lib/sq_mini_racer_extension.bundle(0x10d5e79af) [0x10d5e79af]
/Users/lloeki/Workspace/github.com/sqreen/mini_racer/lib/sq_mini_racer_extension.bundle(_ZN11IsolateInfo4initEP12SnapshotInfo+0xc2) [0x10d3ba012]
/Users/lloeki/Workspace/github.com/sqreen/mini_racer/lib/sq_mini_racer_extension.bundle(_ZL22rb_context_init_unsafemmm+0x126) [0x10d3bc016]
/Users/lloeki/.rubies/ruby-2.7.1/bin/ruby(vm_call_cfunc+0x16c) [0x106eb0cdc]
/Users/lloeki/.rubies/ruby-2.7.1/bin/ruby(vm_exec_core+0x38b0) [0x106e97050]
```