### PR TITLE
Use libv8 node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: Test
+on:
+  - push
+
+jobs:
+  test-darwin:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - "10.15"
+          - "11.0"
+        platform:
+          - x86_64
+          # arm64
+    name: Test (darwin)
+    runs-on: macos-${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Bundle
+        run: bundle install
+      - name: Compile
+        run: bundle exec rake compile
+      - name: Test
+        run: bundle exec rake test
+  test-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+        platform:
+          - amd64
+          - arm64
+          # arm
+          # ppc64le
+          # s390x
+        libc:
+          - gnu
+          - musl
+    name: Build (linux)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Enable ${{ matrix.platform }} platform
+        id: qemu
+        if: ${{ matrix.platform != 'amd64' }}
+        run: |
+          docker run --privileged --rm tonistiigi/binfmt:latest --install ${{ matrix.platform }} | tee platforms.json
+          echo "::set-output name=platforms::$(cat platforms.json)"
+      - name: Start container
+        id: container
+        run: |
+          case ${{ matrix.libc }} in
+            gnu)
+              echo 'ruby:${{ matrix.ruby }}'
+              ;;
+            musl)
+              echo 'ruby:${{ matrix.ruby }}-alpine'
+              ;;
+          esac > container_image
+          echo "::set-output name=image::$(cat container_image)"
+          docker run --rm -d -v "${PWD}":"${PWD}" -w "${PWD}" --platform linux/${{ matrix.platform }} $(cat container_image) /bin/sleep 64d | tee container_id
+          docker exec -w "${PWD}" $(cat container_id) uname -a
+          echo "::set-output name=id::$(cat container_id)"
+      - name: Install Alpine system dependencies
+        if: ${{ matrix.libc == 'musl' }}
+        run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} apk add --no-cache build-base linux-headers bash python2 python3 git curl tar clang binutils-gold
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Bundle
+        run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} bundle install
+      - name: Compile
+        run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} bundle exec rake compile
+      - name: Test
+        run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "10.15"
-          - "11.0"
+          - '10.15'
+          - '11.0'
         platform:
           - x86_64
           # arm64
@@ -29,11 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.4
-          - 2.5
-          - 2.6
-          - 2.7
-          - 3.0
+          - '2.4'
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '3.0'
         platform:
           - amd64
           - arm64
@@ -43,7 +43,7 @@ jobs:
         libc:
           - gnu
           - musl
-    name: Build (linux)
+    name: Test (linux)
     runs-on: ubuntu-20.04
     steps:
       - name: Enable ${{ matrix.platform }} platform

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,31 @@
 language: ruby
 rvm:
+  - 2.4
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
   - ruby-head
+arch:
+  - amd64
+  - arm64
 matrix:
   include:
-    - rvm: 2.5.1
+    - rvm: 2.5
       os: osx
       osx_image: xcode9.4
+    - rvm: 2.6
+      os: osx
+      osx_image: xcode11.3
+    - rvm: 2.6
+      os: osx
+      osx_image: xcode12.2
+    - rvm: 2.7
+      os: osx
+      osx_image: xcode12.2
+    - rvm: 3.0
+      os: osx
+      osx_image: xcode12.2
 dist: xenial
 sudo: true
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+os: linux
 rvm:
   - 2.4
   - 2.5
@@ -9,7 +10,7 @@ rvm:
 arch:
   - amd64
   - arm64
-matrix:
+jobs:
   include:
     - rvm: 2.5
       os: osx
@@ -23,11 +24,7 @@ matrix:
     - rvm: 2.7
       os: osx
       osx_image: xcode12.2
-    - rvm: 3.0
-      os: osx
-      osx_image: xcode12.2
 dist: xenial
-sudo: true
 before_install:
   - gem update --system
   - gem install bundler -v 1.16.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - rvm: 2.5.1
       os: osx
       osx_image: xcode9.4
-dist: trusty
+dist: xenial
 sudo: true
 before_install:
   - gem update --system

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG RUBY_VERSION=2.7
 FROM ruby:${RUBY_VERSION}
 
+RUN test ! -f /etc/alpine-release || apk add --no-cache build-base git
+
 # without this `COPY .git`, we get the following error:
 #   fatal: not a git repository (or any of the parent directories): .git
 # but with it we need the full gem just to compile the extension because

--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -19,6 +19,8 @@ $CPPFLAGS += " -fvisibility=hidden "
 $CPPFLAGS += " -Wno-reserved-user-defined-literal" if IS_DARWIN
 
 $LDFLAGS.insert(0, " -stdlib=libc++ ") if IS_DARWIN
+$LDFLAGS += " -Wl,--no-undefined " unless IS_DARWIN
+$LDFLAGS += " -Wl,-undefined,error " if IS_DARWIN
 
 if ENV['CXX']
   puts "SETTING CXX"

--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -19,8 +19,10 @@ $CPPFLAGS += " -fvisibility=hidden "
 $CPPFLAGS += " -Wno-reserved-user-defined-literal" if IS_DARWIN
 
 $LDFLAGS.insert(0, " -stdlib=libc++ ") if IS_DARWIN
-$LDFLAGS += " -Wl,--no-undefined " unless IS_DARWIN
-$LDFLAGS += " -Wl,-undefined,error " if IS_DARWIN
+
+# check for missing symbols at link time
+# $LDFLAGS += " -Wl,--no-undefined " unless IS_DARWIN
+# $LDFLAGS += " -Wl,-undefined,error " if IS_DARWIN
 
 if ENV['CXX']
   puts "SETTING CXX"

--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -1,7 +1,7 @@
 require 'mkmf'
 require_relative '../../lib/mini_racer/version'
-gem 'libv8', MiniRacer::LIBV8_VERSION
-require 'libv8'
+gem 'libv8-node', MiniRacer::LIBV8_NODE_VERSION
+require 'libv8-node'
 
 IS_DARWIN = RUBY_PLATFORM =~ /darwin/
 
@@ -57,7 +57,7 @@ if enable_config('debug') || enable_config('asan')
   CONFIG['debugflags'] << ' -ggdb3 -O0'
 end
 
-Libv8.configure_makefile
+Libv8::Node.configure_makefile
 
 if enable_config('asan')
   $CPPFLAGS.insert(0, " -fsanitize=address ")

--- a/lib/mini_racer/version.rb
+++ b/lib/mini_racer/version.rb
@@ -2,5 +2,5 @@
 
 module MiniRacer
   VERSION = "0.3.1"
-  LIBV8_NODE_VERSION = "~> 15.5.1.0.beta1"
+  LIBV8_NODE_VERSION = "~> 15.12.0.0.beta1"
 end

--- a/lib/mini_racer/version.rb
+++ b/lib/mini_racer/version.rb
@@ -2,5 +2,5 @@
 
 module MiniRacer
   VERSION = "0.3.1"
-  LIBV8_VERSION = "~> 8.4.255"
+  LIBV8_NODE_VERSION = "~> 15.5.1.0.beta1"
 end

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "m"
 
-  spec.add_dependency 'libv8', MiniRacer::LIBV8_VERSION
+  spec.add_dependency 'libv8-node', MiniRacer::LIBV8_NODE_VERSION
   spec.require_paths = ["lib", "ext"]
 
   spec.extensions = ["ext/mini_racer_loader/extconf.rb", "ext/mini_racer_extension/extconf.rb"]


### PR DESCRIPTION
This is a PR for people to try `mini_racer` using `libv8-node` built for Apple M1 or musl.

Note: this is only tested using a `rbenv install`'d Ruby (which builds as `arm64`), and untested using the system-provided Ruby (which is built as `arm64e`) as I have not yet found a way to build libv8/node as `arm64e`.

Since I don't fully consider `libv8-node` [ready for prime time yet](https://github.com/sqreen/ruby-libv8-node/issues), the original intent is not to merge this as is (if ever), but provide an easy testing ground via:

```ruby
# Gemfile
gem 'mini_racer', github: 'rubyjs/mini_racer', branch: 'refs/pull/186/head'
# or
gem 'mini_racer', github: 'sqreen/mini_racer', branch: 'use-libv8-node'
```