### PR TITLE
Prevent segfaults related to infinite marshal recursion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Gemfile.lock
 lib/mini_racer_extension.so
 lib/mini_racer_loader.so
 *.bundle
+.vscode/

--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -194,7 +194,9 @@ private:
     Isolate* isolate;
     bool isActive;
 
-    void IncDepth(int inc) {
+    void IncDepth(int direction) {
+        int inc = direction > 0 ? 1 : -1;
+
         size_t depth = (size_t)this->isolate->GetData(MARSHAL_STACKDEPTH_VALUE);
 
         // don't decrement past 0

--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -140,10 +140,10 @@ module MiniRacer
       end
     end
 
-    def initialize(max_memory: nil, timeout: nil, isolate: nil, ensure_gc_after_idle: nil, snapshot: nil)
+    def initialize(max_memory: nil, timeout: nil, isolate: nil, ensure_gc_after_idle: nil, snapshot: nil, marshal_stack_depth: nil)
       options ||= {}
 
-      check_init_options!(isolate: isolate, snapshot: snapshot, max_memory: max_memory, ensure_gc_after_idle: ensure_gc_after_idle, timeout: timeout)
+      check_init_options!(isolate: isolate, snapshot: snapshot, max_memory: max_memory, marshal_stack_depth: marshal_stack_depth, ensure_gc_after_idle: ensure_gc_after_idle, timeout: timeout)
 
       @functions = {}
       @timeout = nil
@@ -151,6 +151,7 @@ module MiniRacer
       @current_exception = nil
       @timeout = timeout
       @max_memory = max_memory
+      @marshal_stack_depth = marshal_stack_depth
 
       # false signals it should be fetched if requested
       @isolate = isolate || false
@@ -379,11 +380,12 @@ module MiniRacer
       rp.close if rp
     end
 
-    def check_init_options!(isolate:, snapshot:, max_memory:, ensure_gc_after_idle:, timeout:)
+    def check_init_options!(isolate:, snapshot:, max_memory:, marshal_stack_depth:, ensure_gc_after_idle:, timeout:)
       assert_option_is_nil_or_a('isolate', isolate, Isolate)
       assert_option_is_nil_or_a('snapshot', snapshot, Snapshot)
 
       assert_numeric_or_nil('max_memory', max_memory, min_value: 10_000)
+      assert_numeric_or_nil('marshal_stack_depth', marshal_stack_depth, min_value: 1)
       assert_numeric_or_nil('ensure_gc_after_idle', ensure_gc_after_idle, min_value: 1)
       assert_numeric_or_nil('timeout', timeout, min_value: 1)
 

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -855,11 +855,21 @@ raise FooError, "I like foos"
     assert_equal :foo, context.eval("Symbol('foo')")
   end
 
-  def test_cyclical_object
+  def test_cyclical_object_js
     context = MiniRacer::Context.new()
     context.attach("a", proc{|a| a})
-    assert_equal :foo, context.eval("let arr = []; arr.push(arr); a(arr)")
+
+    # Already marshalled object references are replaced with null.
+    #  This prevents a segfault in this likely-an-error case.
+    assert_equal [[nil]], context.eval("let arr = []; arr.push(arr); a(arr)")
   end
+
+  ## This case just hangs everything.
+  # def test_cyclical_object_rb
+  #   context = MiniRacer::Context.new()
+  #   context.attach("a", proc{ arr = []; arr << arr; arr})
+  #   context.eval("a()")
+  # end
 
   def test_proxy_support
     js = <<~JS

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -855,6 +855,12 @@ raise FooError, "I like foos"
     assert_equal :foo, context.eval("Symbol('foo')")
   end
 
+  def test_cyclical_object
+    context = MiniRacer::Context.new()
+    context.attach("a", proc{|a| a})
+    assert_equal :foo, context.eval("let arr = []; arr.push(arr); a(arr)")
+  end
+
   def test_proxy_support
     js = <<~JS
       function MyProxy(reference) {


### PR DESCRIPTION
Creates a marshal stackdepth option, allowing protection against exceptional object structures. See testcases for examples.
Been a while since I've made changes in here, would love some critical eyes on the code.