### PR TITLE
Update the locale test with a hardcoded date

### DIFF
--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -10,10 +10,10 @@ class MiniRacerTest < Minitest::Test
 
 
   def test_locale
-    val = MiniRacer::Context.new.eval("new Date().toLocaleDateString('es-MX');")
+    val = MiniRacer::Context.new.eval("new Date('April 28 2021').toLocaleDateString('es-MX');")
     assert_equal '28/4/2021', val
 
-    val = MiniRacer::Context.new.eval("new Date().toLocaleDateString('en-US');")
+    val = MiniRacer::Context.new.eval("new Date('April 28 2021').toLocaleDateString('en-US');")
     assert_equal '4/28/2021', val
   end
 


### PR DESCRIPTION
We noticed this was failing here: https://github.com/rubyjs/mini_racer/issues/199#issuecomment-834187186. 

This PR hardcodes the initial date—as is this test will only pass if the system date is April 28, 2021.