### PR TITLE
gemspec: Drop configuration for executables

### DIFF
--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(benchmark|test|spec|features|examples)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
This gem exposes 0 executables.