### PR TITLE
CI: Drop 2.4 from the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 os: linux
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7


### PR DESCRIPTION
This PR attempts to make the build green, by dropping unsupported 2.4.

The error message in the build was: 

    mini_racer was resolved to 0.4.0, which depends on
      Ruby (>= 2.5)

8148e784b5f63036bc952c29e566e3dd4d8a0d4d removed 2.4 from the GitHub Actions matrix.