### PR TITLE
Travis CI: Attempt to use rvm-installed Bundler, RubyGems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,4 @@ jobs:
       os: osx
       osx_image: xcode12.2
 dist: xenial
-before_install:
-  - gem update --system
-  - gem install bundler -v 1.16.2
 cache: bundler


### PR DESCRIPTION
This is an attempt to make the CI configuration smaller, more confident. I am guessing that we are not relying on Bundler 1.x-specific behavior, so this commit is a try-out of that.

I was inspired to do this when I saw that the `gem update --system` change took very long in builds.

<img width="1489" alt="bild" src="https://user-images.githubusercontent.com/211/120761737-cb41bc00-c515-11eb-8063-6929aff41b78.png">
