### PR TITLE
Update to use libv8-node 16.x

### DIFF
--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -11,7 +11,7 @@ $CPPFLAGS += " -Wall" unless $CPPFLAGS.split.include? "-Wall"
 $CPPFLAGS += " -g" unless $CPPFLAGS.split.include? "-g"
 $CPPFLAGS += " -rdynamic" unless $CPPFLAGS.split.include? "-rdynamic"
 $CPPFLAGS += " -fPIC" unless $CPPFLAGS.split.include? "-rdynamic" or IS_DARWIN
-$CPPFLAGS += " -std=c++0x"
+$CPPFLAGS += " -std=c++14"
 $CPPFLAGS += " -fpermissive"
 $CPPFLAGS += " -DV8_COMPRESS_POINTERS"
 $CPPFLAGS += " -fvisibility=hidden "

--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -13,7 +13,7 @@ $CPPFLAGS += " -rdynamic" unless $CPPFLAGS.split.include? "-rdynamic"
 $CPPFLAGS += " -fPIC" unless $CPPFLAGS.split.include? "-rdynamic" or IS_DARWIN
 $CPPFLAGS += " -std=c++14"
 $CPPFLAGS += " -fpermissive"
-$CPPFLAGS += " -DV8_COMPRESS_POINTERS"
+#$CPPFLAGS += " -DV8_COMPRESS_POINTERS"
 $CPPFLAGS += " -fvisibility=hidden "
 
 $CPPFLAGS += " -Wno-reserved-user-defined-literal" if IS_DARWIN

--- a/lib/mini_racer/version.rb
+++ b/lib/mini_racer/version.rb
@@ -2,5 +2,5 @@
 
 module MiniRacer
   VERSION = "0.4.0"
-  LIBV8_NODE_VERSION = "~> 15.14.0.0"
+  LIBV8_NODE_VERSION = "~> 16.3.0.0"
 end

--- a/lib/mini_racer/version.rb
+++ b/lib/mini_racer/version.rb
@@ -2,5 +2,5 @@
 
 module MiniRacer
   VERSION = "0.4.0"
-  LIBV8_NODE_VERSION = "~> 16.4.2.0"
+  LIBV8_NODE_VERSION = "~> 16.10.0.0"
 end

--- a/lib/mini_racer/version.rb
+++ b/lib/mini_racer/version.rb
@@ -2,5 +2,5 @@
 
 module MiniRacer
   VERSION = "0.4.0"
-  LIBV8_NODE_VERSION = "~> 16.3.0.0"
+  LIBV8_NODE_VERSION = "~> 16.4.2.0"
 end


### PR DESCRIPTION
Based on V8 9.0, with node 16 being the new LTS, node 15 now being unsupported. It
notably introduces single threaded mode.

Requiring c++14 is apparently the only change needed for this major. A
separate PR will add a more helpful install time check for compiler
requirements.