### PR TITLE
False positive on OOM error

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -469,7 +469,6 @@ nogvl_context_eval(void* arg) {
 
     if (eval_params->max_memory > 0) {
         IsolateData::Set(isolate, IsolateData::MEM_SOFTLIMIT_MAX, eval_params->max_memory);
-printf("lim: %lu %lu aaa\n", (size_t)IsolateData::Get(isolate, IsolateData::MEM_SOFTLIMIT_MAX), eval_params->max_memory);
         if (!isolate_info->added_gc_cb) {
         isolate->AddGCEpilogueCallback(gc_callback);
             isolate_info->added_gc_cb = true;

--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -467,6 +467,15 @@ nogvl_context_eval(void* arg) {
 
     IsolateData::Init(isolate);
 
+    if (eval_params->max_memory > 0) {
+        IsolateData::Set(isolate, IsolateData::MEM_SOFTLIMIT_MAX, eval_params->max_memory);
+printf("lim: %lu %lu aaa\n", (size_t)IsolateData::Get(isolate, IsolateData::MEM_SOFTLIMIT_MAX), eval_params->max_memory);
+        if (!isolate_info->added_gc_cb) {
+        isolate->AddGCEpilogueCallback(gc_callback);
+            isolate_info->added_gc_cb = true;
+        }
+    }
+
     MaybeLocal<Script> parsed_script;
 
     if (eval_params->filename) {
@@ -491,14 +500,6 @@ nogvl_context_eval(void* arg) {
         result->message->Reset(isolate, trycatch.Exception());
     } else {
         // parsing successful
-        if (eval_params->max_memory > 0) {
-            IsolateData::Set(isolate, IsolateData::MEM_SOFTLIMIT_MAX, eval_params->max_memory);
-            if (!isolate_info->added_gc_cb) {
-            isolate->AddGCEpilogueCallback(gc_callback);
-                isolate_info->added_gc_cb = true;
-            }
-        }
-
         if (eval_params->marshal_stackdepth > 0) {
             StackCounter::SetMax(isolate, eval_params->marshal_stackdepth);
         }

--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -470,7 +470,7 @@ nogvl_context_eval(void* arg) {
     if (eval_params->max_memory > 0) {
         IsolateData::Set(isolate, IsolateData::MEM_SOFTLIMIT_MAX, eval_params->max_memory);
         if (!isolate_info->added_gc_cb) {
-        isolate->AddGCEpilogueCallback(gc_callback);
+            isolate->AddGCEpilogueCallback(gc_callback);
             isolate_info->added_gc_cb = true;
         }
     }


### PR DESCRIPTION
It took us a few weeks to nail down this repro because it was so incredibly finicky.

I recently switched from an execution context which ran one eval with all the code into it, into multiple evals on the same context. Because of this, we ran into this crucial and very hard to isolate issue where the GC callback was happening between `IsolateData::Init` and `IsolateData::Set` -- when the GC callback was hit, the 'max memory' field was 0 meaning the check of `current memory > max memory` would always trigger.

In this incredibly hard to reproduce (we were never able to create a mini_racer cross-machine portable repro) case, it would erroneously report an out of memory.

The fix for this is to move the setter and callback right next to the data init call.

We've run this change on the production servers and verified all the live repro cases we had previously and by the time you take a look at this, it will have baked for a while.

Please let me know if you have any questions.