### PR TITLE
bump required ruby version to >= 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.5'
           - '2.6'
           - '2.7'
           - '3.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 os: linux
 rvm:
-  - 2.5
   - 2.6
   - 2.7
   - 3.0
@@ -11,9 +10,6 @@ arch:
   - arm64
 jobs:
   include:
-    - rvm: 2.5
-      os: osx
-      osx_image: xcode9.4
     - rvm: 2.6
       os: osx
       osx_image: xcode11.3

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
 
   spec.extensions = ["ext/mini_racer_loader/extconf.rb", "ext/mini_racer_extension/extconf.rb"]
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 end


### PR DESCRIPTION
In https://github.com/rubyjs/mini_racer/commit/06cca5bf190017516650e2f4a1d27c586c12dfda#diff-30d3134eb72fcd96ce343d5c0359684a5545843b47d7cba45732d3e360cf322f the required ruby version was bumped to >= 2.5.

I just stumbled across [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/) where it lists Ruby 2.5's EOL date to 2021-03-31. Based on [@SamSaffron's comment](https://github.com/rubyjs/mini_racer/issues/190#issuecomment-824609197) and the README stating that only non-EOL'd versions of Ruby will be supported, I guess, we could bump the version once more?

It's just a suggestion, I just stumbled across the Ruby maintenance overview.