### PR TITLE
CI: Run gem update --system on Linux builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} apk add --no-cache build-base linux-headers bash python2 python3 git curl tar clang binutils-gold
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Update Rubygems
+        run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} gem update --system
       - name: Bundle
         run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} bundle install
       - name: Compile


### PR DESCRIPTION
This is an attempt to fix the currently broken builds on linux/amd64.

I'm not sure if it's a good idea to "blindly" update rubygems to the latest version, but I thought it's worth a try if it fixes the builds.

https://github.com/rubyjs/mini_racer/runs/4892980034?check_suite_focus=true for example is failing with, which looked pretty obvious to me: the incorrect libv8-node version/architecture has been installed:

```
[…]
linking shared-object mini_racer_extension.so
g++: error: /usr/local/bundle/gems/libv8-node-16.10.0.0-x86_64-linux/vendor/v8/x86_64-linux/libv8/obj/libv8_monolith.a: No such file or directory
gmake: *** [Makefile:262: mini_racer_extension.so] Error 1
rake aborted!
[…]
```
