### PR TITLE
Readme: Add note about V8 single threaded platform mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ MiniRacer has an adapter for [execjs](https://github.com/rails/execjs) so it can
 
 ### A note about Ruby version Support
 
-MiniRacer only supports non-EOL versions of Ruby. See [Ruby](https://www.ruby-lang.org/en/downloads) to see the list of non-EOL Rubies.
+MiniRacer only supports non-EOL versions of Ruby. See [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/) for the list of non-EOL Rubies.
 
 If you require support for older versions of Ruby install an older version of the gem.
 

--- a/README.md
+++ b/README.md
@@ -112,16 +112,21 @@ context.eval('bar()', filename: 'a/bar.js')
 
 ### Fork safety
 
-Some Ruby web servers employ forking (for example unicorn or puma in clustered mode). V8 is not fork safe.
-Sadly Ruby does not have support for fork notifications per [#5446](https://bugs.ruby-lang.org/issues/5446).
+Some Ruby web servers employ forking (for example unicorn or puma in clustered mode). V8 is not fork safe by default and sadly Ruby does not have support for fork notifications per [#5446](https://bugs.ruby-lang.org/issues/5446).
+
+Since 0.6.1 mini_racer does support V8 single threaded platform mode which should remove most forking related issues. To enable run this before using `MiniRacer::Context`:
+
+```ruby
+MiniRacer::Platform.set_flags!(:single_threaded)
+```
 
 If you want to ensure your application does not leak memory after fork either:
 
-1. Ensure no MiniRacer::Context objects are created in the master process
+1. Ensure no `MiniRacer::Context` objects are created in the master process
 
 Or
 
-2. Dispose manually of all MiniRacer::Context objects prior to forking
+2. Dispose manually of all `MiniRacer::Context` objects prior to forking
 
 ```ruby
 # before fork


### PR DESCRIPTION
I'm building up a little troubleshooting guide and noticed that we do not mention the support of the single threaded platform mode anywhere.

Also: I was looking when Ruby 2.6 is going EOL'd (it's 2022-03-31) and changed the link to the correct  "Ruby Maintenance Branches" site where there is an overview.
