### PR TITLE
fix an incorrect syntax

### DIFF
--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -203,7 +203,7 @@ module MiniRacer
       end
 
       if !(File === f)
-        raise ArgumentError("file_or_io")
+        raise ArgumentError, "file_or_io"
       end
 
       write_heap_snapshot_unsafe(f)


### PR DESCRIPTION
```
/Users/jasl/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/mini_racer-0.6.2/lib/mini_racer.rb:205:in `write_heap_snapshot': undefined method `ArgumentError' for #<MiniRacer::Context:0x00000001024a19d0 @functions={}, @timeout=nil, @max_memory=nil, @current_exception=nil, @marshal_stack_depth=nil, @isolate=false, @ensure_gc_after_idle=nil, @disposed=false, @callback_mutex=#<Thread::Mutex:0x000000010249a860>, @callback_running=false, @thread_raise_called=false, @eval_thread=nil> (NoMethodError)

        raise ArgumentError("file_or_io")
              ^^^^^^^^^^^^^
```