### PR TITLE
CI: Add macOS 12.3 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ jobs:
       matrix:
         os:
           - '10.15'
-          - '11.0'
+          - '11'
+          - '12'
         platform:
           - x86_64
           # arm64


### PR DESCRIPTION
It's a little weird, that the README and docs don't mention macOS 12 Monterey support for Github Action runners, but it is available and there are official releases for it (https://github.com/actions/virtual-environments/releases).

In this PR I just added macOS 12 to the build matrix.

PS: It looks like the macOS 12 runners are not quite working yet, see https://github.community/t/macos-12-runner-not-available/242185/2 🤔 

Update: Yep, it's not working yet, see https://github.com/tisba/mini_racer/actions/runs/2159798787