### PR TITLE
Fix GitHub Actions and add tests for mutable strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,69 +1,92 @@
-name: Test
+name: Tests
+
 on:
-  - push
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test-truffleruby:
-    name: Test TruffleRuby
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - "macos-11"
+          - "macos-12"
+          - "ubuntu-20.04"
+        ruby:
+          - "truffleruby+graalvm-head"
+
+    name: ${{ matrix.os }} - ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+
     env:
       TRUFFLERUBYOPT: "--jvm --polyglot"
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: truffleruby+graalvm-head
-      - name: Install GraalVM js component
-        run: if ! gu list | grep '^js '; then gu install js; fi
-      - name: Bundle
-        run: bundle install
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Install GraalVM JS component
+        run: gu install js
       - name: Compile
         run: bundle exec rake compile
       - name: Test
         run: bundle exec rake test
+
   test-darwin:
     strategy:
       fail-fast: false
       matrix:
         os:
-          - '10.15'
-          - '11.0'
-        platform:
-          - x86_64
-          # arm64
-    name: Test (darwin)
-    runs-on: macos-${{ matrix.os }}
+          - "macos-11"
+          - "macos-12"
+        ruby:
+          - "ruby-2.6"
+          - "ruby-2.7"
+          - "ruby-3.0"
+          - "ruby-3.1"
+
+    name: ${{ matrix.os }} - ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Bundle
-        run: bundle install
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: Compile
         run: bundle exec rake compile
       - name: Test
         run: bundle exec rake test
+
   test-linux:
     strategy:
       fail-fast: false
       matrix:
         ruby:
-          - '2.6'
-          - '2.7'
-          - '3.0'
-          - '3.1'
+          - "2.6"
+          - "2.7"
+          - "3.0"
+          - "3.1"
         platform:
-          - amd64
-          - arm64
-          # arm
-          # ppc64le
-          # s390x
+          - "amd64"
+          - "arm64"
         libc:
-          - gnu
-          - musl
-    name: Test (linux)
+          - "gnu"
+          - "musl"
+        exclude:
+          # there's no libv8-node (v16) for aarch64-linux-musl at the moment
+          - platform: "arm64"
+            libc: "musl"
+
+    name: linux-${{ matrix.platform }} - ruby-${{ matrix.ruby }} - ${{ matrix.libc }}
     runs-on: ubuntu-20.04
+
     steps:
       - name: Enable ${{ matrix.platform }} platform
         id: qemu
@@ -88,9 +111,11 @@ jobs:
           echo "::set-output name=id::$(cat container_id)"
       - name: Install Alpine system dependencies
         if: ${{ matrix.libc == 'musl' }}
-        run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} apk add --no-cache build-base linux-headers bash python2 python3 git curl tar clang binutils-gold
+        run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} apk add --no-cache build-base bash git
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Update Rubygems
+        run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} gem update --system
       - name: Bundle
         run: docker exec -w "${PWD}" ${{ steps.container.outputs.id }} bundle install
       - name: Compile

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -649,7 +649,7 @@ raise FooError, "I like foos"
 
   def test_timeout_in_ruby_land
     context = MiniRacer::Context.new(timeout: 50)
-    context.attach('sleep', proc{ sleep 0.1 })
+    context.attach('sleep', proc{ sleep 0.5 })
     assert_raises(MiniRacer::ScriptTerminatedError) do
       context.eval('sleep(); "hi";')
     end
@@ -759,7 +759,7 @@ raise FooError, "I like foos"
 
     context.eval("'#{"x" * 10_000_000}'")
 
-    sleep 0.005
+    sleep 0.01
 
     end_heap = context.heap_stats[:used_heap_size]
 
@@ -906,7 +906,7 @@ raise FooError, "I like foos"
     skip "TruffleRuby does not yet implement marshal_stack_depth" if RUBY_ENGINE == "truffleruby"
     context = MiniRacer::Context.new(marshal_stack_depth: 5)
     context.attach("a", proc{|a| a})
-  
+
     js = <<~JS
       var d=0;
       function get(z) {

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -8,7 +8,6 @@ class MiniRacerTest < Minitest::Test
   # see `test_platform_set_flags_works` below
   MiniRacer::Platform.set_flags! :use_strict
 
-
   def test_locale
     skip "TruffleRuby does not have all js timezone by default" if RUBY_ENGINE == "truffleruby"
     val = MiniRacer::Context.new.eval("new Date('April 28 2021').toLocaleDateString('es-MX');")
@@ -439,7 +438,7 @@ raise FooError, "I like foos"
   end
 
   def test_snapshots_can_be_warmed_up_with_no_side_effects
-    # shamelessly insipired by https://github.com/v8/v8/blob/5.3.254/test/cctest/test-serialize.cc#L792-L854
+    # shamelessly inspired by https://github.com/v8/v8/blob/5.3.254/test/cctest/test-serialize.cc#L792-L854
     snapshot_source = <<-JS
       function f() { return Math.sin(1); }
       var a = 5;
@@ -985,16 +984,16 @@ raise FooError, "I like foos"
     context.attach("print", proc {|f| puts f})
 
     context.eval <<~JS
-    WebAssembly
-      .instantiate(new Uint8Array(loadwasm()), {
-        wasi_snapshot_preview1: {
-          proc_exit: function() { print("exit"); },
-          args_get: function() { return 0 },
-          args_sizes_get: function() { return 0 }
-        }
-      })
-      .then(i => { instance = i["instance"];})
-      .catch(e => print(e.toString()));
+      WebAssembly
+        .instantiate(new Uint8Array(loadwasm()), {
+          wasi_snapshot_preview1: {
+            proc_exit: function() { print("exit"); },
+            args_get: function() { return 0 },
+            args_sizes_get: function() { return 0 }
+          }
+        })
+        .then(i => { instance = i["instance"];})
+        .catch(e => print(e.toString()));
     JS
 
     while !context.eval("instance") do
@@ -1033,5 +1032,28 @@ raise FooError, "I like foos"
         doit();
         JS
     end
+  end
+
+  def test_eval_returns_unfrozen_string
+    context = MiniRacer::Context.new
+    result = context.eval("'Hello George!'")
+    assert_equal("Hello George!", result)
+    assert_equal(false, result.frozen?)
+  end
+
+  def test_call_returns_unfrozen_string
+    context = MiniRacer::Context.new
+    context.eval('function hello(name) { return "Hello " + name + "!" }')
+    result = context.call('hello', 'George')
+    assert_equal("Hello George!", result)
+    assert_equal(false, result.frozen?)
+  end
+
+  def test_callback_string_arguments_are_not_frozen
+    context = MiniRacer::Context.new
+    context.attach("test", proc{ |text| text.frozen? })
+
+    frozen = context.eval("test('Hello George!')")
+    assert_equal(false, frozen)
   end
 end


### PR DESCRIPTION
* Disable tests with `musl` for arm64 because there's no `libv8-node` gem for aarch64-linux-musl at the moment
* Fix tests on older Ruby versions by running `gem update --system`
* Removes macOS 10.15 from the matrix (it will be unsupported by GitHub on 2022-08-30 anyway)
* Adds macOS 12 to the matrix
* Run TruffleRuby job on macOS as well
* Use `ruby/setup-ruby` action where possible and update `actions/checkout` to v3
* Run tests for pull requests

It also
* Slightly raises sleep durations for some tests to fix CI failures on macOS
* Adds tests for mutable string arguments and return values

This PR makes https://github.com/rubyjs/mini_racer/pull/247 and https://github.com/rubyjs/mini_racer/pull/237 obsolete.

(Please don't squash commits on merge.)