### PR TITLE
Mention all the requirements for MiniRacer on TruffleRuby

### DIFF
--- a/lib/mini_racer/truffleruby.rb
+++ b/lib/mini_racer/truffleruby.rb
@@ -71,7 +71,9 @@ module MiniRacer
       end
 
       unless Polyglot.languages.include? "js"
-        warn "You also need to install the 'js' component with 'gu install js' on GraalVM 22.2+", uplevel: 0 if $VERBOSE
+        raise "The language 'js' is not available, you likely need to `export TRUFFLERUBYOPT='--jvm --polyglot'`\n" \
+          "You also need to install the 'js' component with 'gu install js' on GraalVM 22.2+\n" \
+          "Note that you need TruffleRuby+GraalVM and not just the TruffleRuby standalone to use MiniRacer"
       end
 
       @context = Polyglot::InnerContext.new(on_cancelled: -> { 


### PR DESCRIPTION
* Raise there instead of waiting for the `@context.eval` below, for a clearer error.
* Same text as https://github.com/rails/execjs/blob/e553b3f8a3a7fbfbd03b6e615cf597204a2da3a7/lib/execjs/graaljs_runtime.rb#L138-L140