### PR TITLE
pass exception text into javascript

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -1281,7 +1281,8 @@ gvl_ruby_callback(void* data) {
 
     if(callback_data.failed) {
         rb_iv_set(parent, "@current_exception", result);
-        args->GetIsolate()->ThrowException(String::NewFromUtf8Literal(args->GetIsolate(), "Ruby exception"));
+        VALUE message = rb_funcall(result, rb_intern("message"), 0);
+        args->GetIsolate()->ThrowException(String::NewFromUtf8(args->GetIsolate(), RSTRING_PTR(message), NewStringType::kNormal, RSTRING_LENINT(message)).ToLocalChecked());
     }
     else {
         HandleScope scope(args->GetIsolate());

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -877,7 +877,7 @@ raise FooError, "I like foos"
     error_message = "Actual Error Message"
     context.attach("a", proc{|a| raise error_message})
 
-    assert_equal error_message, context.eval("try { a(); \'no throw\' } catch (e) { e }")
+    assert_equal error_message, context.eval("try { a(); } catch (e) { e }")
   end
 
   def test_symbol_support

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -872,6 +872,14 @@ raise FooError, "I like foos"
     end
   end
 
+  def test_capture_ruby_exception_message
+    context = MiniRacer::Context.new()
+    error_message = "Actual Error Message"
+    context.attach("a", proc{|a| raise error_message})
+
+    assert_equal error_message, context.eval("try { a(); \'no throw\' } catch (e) { e }")
+  end
+
   def test_symbol_support
     context = MiniRacer::Context.new()
     assert_equal :foo, context.eval("Symbol('foo')")


### PR DESCRIPTION
Our usage of mini_racer needs some way for exceptional cases in ruby to be able to be handled in javascript. Currently there is no way to identify what exception happened when it is caught by JS.

Also not sure what I do or do not need to do with handles and scopes here to make this string activity safe. Please let me know!