### PR TITLE
Update to libv8-node 17.x Take 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,6 @@ jobs:
         libc:
           - "gnu"
           - "musl"
-        exclude:
-          # there's no libv8-node (v16) for aarch64-linux-musl at the moment
-          - platform: "arm64"
-            libc: "musl"
 
     name: linux-${{ matrix.platform }} - ruby-${{ matrix.ruby }} - ${{ matrix.libc }}
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           - "ruby-2.7"
           - "ruby-3.0"
           - "ruby-3.1"
+          - "ruby-3.2"
 
     name: ${{ matrix.os }} - ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
@@ -73,6 +74,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
         platform:
           - "amd64"
           - "arm64"

--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -658,7 +658,7 @@ static VALUE convert_v8_to_ruby(Isolate* isolate, Local<Context> context,
 
     if (value->IsSymbol()) {
 	v8::String::Utf8Value symbol_name(isolate,
-	    Local<Symbol>::Cast(value)->Name());
+	    Local<Symbol>::Cast(value)->Description(isolate));
 
 	VALUE str_symbol = rb_utf8_str_new(*symbol_name, symbol_name.length());
 

--- a/lib/mini_racer/version.rb
+++ b/lib/mini_racer/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module MiniRacer
-  VERSION = "0.6.3"
-  LIBV8_NODE_VERSION = "~> 16.10.0.0"
+  VERSION = "0.6.1"
+  LIBV8_NODE_VERSION = "~> 17.3.1.0"
 end

--- a/lib/mini_racer/version.rb
+++ b/lib/mini_racer/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module MiniRacer
-  VERSION = "0.6.1"
-  LIBV8_NODE_VERSION = "~> 17.3.1.0"
+  VERSION = "0.6.3"
+  LIBV8_NODE_VERSION = "~> 17.9.1.0"
 end

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -8,13 +8,24 @@ class MiniRacerTest < Minitest::Test
   # see `test_platform_set_flags_works` below
   MiniRacer::Platform.set_flags! :use_strict
 
-  def test_locale
+  def test_locale_mx
     skip "TruffleRuby does not have all js timezone by default" if RUBY_ENGINE == "truffleruby"
     val = MiniRacer::Context.new.eval("new Date('April 28 2021').toLocaleDateString('es-MX');")
     assert_equal '28/4/2021', val
+  end
 
+  def test_locale_us
+    skip "TruffleRuby does not have all js timezone by default" if RUBY_ENGINE == "truffleruby"
     val = MiniRacer::Context.new.eval("new Date('April 28 2021').toLocaleDateString('en-US');")
     assert_equal '4/28/2021', val
+  end
+
+  def test_locale_fr
+    # TODO: this causes a segfault on Linux
+
+    skip "TruffleRuby does not have all js timezone by default" if RUBY_ENGINE == "truffleruby"
+    val = MiniRacer::Context.new.eval("new Date('April 28 2021').toLocaleDateString('fr-FR');")
+    assert_equal '28/04/2021', val
   end
 
   def test_segfault


### PR DESCRIPTION
Did a rebase of the changes in #232 -- will be taking a look at the segfaults in locale switching introduced after 16.10
Should make 18.x #261 easier to upgrade to.