### PR TITLE
Bump required Ruby to 3.0, as 2.7 is EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,9 @@ jobs:
           - "macos-11"
           - "macos-12"
         ruby:
-          - "ruby-2.6"
-          - "ruby-2.7"
           - "ruby-3.0"
           - "ruby-3.1"
+          - "ruby-3.2"
 
     name: ${{ matrix.os }} - ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
@@ -69,10 +68,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.6"
-          - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
         platform:
           - "amd64"
           - "arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=2.7
+ARG RUBY_VERSION=3.2
 FROM ruby:${RUBY_VERSION}
 
 RUN test ! -f /etc/alpine-release || apk add --no-cache build-base git

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
 
   spec.extensions = ["ext/mini_racer_loader/extconf.rb", "ext/mini_racer_extension/extconf.rb"]
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 3.0'
 end


### PR DESCRIPTION
Ruby 2.7 has been EOL'd as of 2023-03-31 (see https://www.ruby-lang.org/en/downloads/branches/).

While removing references to 2.6/2.7 I noticed, that we did not test against Ruby 3.2 in GH Actions, so I added that.