### PR TITLE
Improved README & CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,7 +17,6 @@
   - Corrected re-raising of exceptions to support strings
   - During early termination of context under certain conditions MiniRacer could crash
 
-
 - 31-12-2021
 
 - 0.6.1
@@ -27,10 +26,10 @@
 
 - 0.6.0
 
-   - Ruby 3.1 support
-   - Fixes memory leak in heap snapshotting
-   - Improved compilation ergonomics in clang
-   - Migrated internal storage in c extension to TypedData
+  - Ruby 3.1 support
+  - Fixes memory leak in heap snapshotting
+  - Improved compilation ergonomics in clang
+  - Migrated internal storage in c extension to TypedData
 
 - 11-04-2021
 
@@ -81,7 +80,7 @@
 
 - 0.2.13
 
-   - FIX: edge case around ensure_gc_after_idle possibly firing when context is not idle
+  - FIX: edge case around ensure_gc_after_idle possibly firing when context is not idle
 
 - 15-05-2020
 
@@ -131,7 +130,7 @@
 
 - 0.2.5
 
-  - FIX: Compatiblity fixes for V8 7 and above @ignisf
+  - FIX: Compatibility fixes for V8 7 and above @ignisf
   - FIX: Memory leak in gc_callback @messense
   - IMPROVEMENT: Added example of sourcemap support @ianks
   - URGENT: you will need this release for latest version of libv8 to work
@@ -148,15 +147,15 @@
 - 0.2.3
 
   - Drop all conditional logic from Mini Racer compilation for clang, always
-	  rely on MacOS being High Sierra or up
+    rely on MacOS being High Sierra or up
 
 - 26-09-2018
 
 - 0.2.2
 
   - WORKAROUND: RUBY_PLATFORM is hardcoded on Ruby compile and can not be
-	trusted for feature detection, use a different technique when checking for
-	macOS Mojave
+    trusted for feature detection, use a different technique when checking for
+    macOS Mojave
 
 - 25-09-2018
 
@@ -184,7 +183,7 @@
 
 - 0.1.14
 
-  - libv8 erronuously bumped to beta, reverted change
+  - libv8 erroneously bumped to beta, reverted change
 
 23-08-2017
 
@@ -197,7 +196,7 @@
 - 0.1.12
 
   - Feature: upgrade libv8 to 5.9
-  - Fix: warning when runnin with ruby warnings enabled (missed @disposed initialize)
+  - Fix: warning when running with ruby warnings enabled (missed @disposed initialize)
 
 18-07-2017
 
@@ -209,16 +208,16 @@
 
 - 0.1.10
 
- - Fix leak: memory leak when disposing a context (20 bytes per context)
- - Feature: added #heap_stats so you can get visibility from context to actual memory usage of isolate
- - Feature: added #dispose so you reclaim all v8 memory right away as opposed to waiting for GC
- - Feature: you can now specify filename in an eval eg: eval('a = 1', filename: 'my_awesome.js')
+  - Fix leak: memory leak when disposing a context (20 bytes per context)
+  - Feature: added #heap_stats so you can get visibility from context to actual memory usage of isolate
+  - Feature: added #dispose so you reclaim all v8 memory right away as opposed to waiting for GC
+  - Feature: you can now specify filename in an eval eg: eval('a = 1', filename: 'my_awesome.js')
 
 09-03-2017
 
 - 0.1.9
 
- - Perf: speed up ruby/node boundary performance when moving large objects
+  - Perf: speed up ruby/node boundary performance when moving large objects
 
 06-02-2017
 
@@ -258,7 +257,6 @@
   - Support more conversions from Ruby back to JS (Hash, Symbol, Array)
   - Support attaching nested objects
 
-
 17-05-2016
 
 - 0.1.2
@@ -276,4 +274,4 @@
 
 - 0.1.1.beta.1
 
-   - First release
+  - First release

--- a/README.md
+++ b/README.md
@@ -6,17 +6,25 @@ Minimal, modern embedded V8 for Ruby.
 
 MiniRacer provides a minimal two way bridge between the V8 JavaScript engine and Ruby.
 
-It was created as an alternative to the excellent [therubyracer](https://github.com/cowboyd/therubyracer). Unlike therubyracer, mini_racer only implements a minimal bridge. This reduces the surface area making upgrading v8 much simpler and exhaustive testing simpler.
+It was created as an alternative to the excellent [therubyracer](https://github.com/cowboyd/therubyracer), which is [no longer maintained](https://github.com/rubyjs/therubyracer/issues/462). Unlike therubyracer, mini_racer only implements a minimal bridge. This reduces the surface area making upgrading v8 much simpler and exhaustive testing simpler.
 
 MiniRacer has an adapter for [execjs](https://github.com/rails/execjs) so it can be used directly with Rails projects to minify assets, run babel or compile CoffeeScript.
 
-### Supported Ruby Versions
+## Supported Ruby Versions & Troubleshooting
 
-MiniRacer only supports non-EOL versions of Ruby. See [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/) for the list of non-EOL Rubies.
+MiniRacer only supports non-EOL versions of Ruby. See [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/) for the list of non-EOL Rubies. If you require support for older versions of Ruby install an older version of the gem.
 
-If you require support for older versions of Ruby install an older version of the gem.
+MiniRacer **does not support** [Ruby built on MinGW](https://github.com/rubyjs/mini_racer/issues/252#issuecomment-1201172236), "pure windows" no Cygwin, no WSL2 (see https://github.com/rubyjs/libv8-node/issues/9).
 
-MiniRacer **does not support** [Ruby built on MinGW](https://github.com/rubyjs/mini_racer/issues/252#issuecomment-1201172236, "pure windows" no Cygwin, no WSL2) (see https://github.com/rubyjs/libv8-node/issues/9).
+If you have a problem installing MiniRacer, please consider the following steps:
+
+* make sure you try the latest released version of `mini_racer`
+* make sure you have Rubygems >= 3.2.13 and bundler >= 2.2.13 installed: `gem update --system`
+* if you are using bundler
+  * make sure it is actually using the latest bundler version: [`bundle update --bundler`](https://bundler.io/v2.4/man/bundle-update.1.html)
+  * make sure to have `PLATFORMS` set correctly in `Gemfile.lock` via [`bundle lock --add-platform`](https://bundler.io/v2.4/man/bundle-lock.1.html#SUPPORTING-OTHER-PLATFORMS)
+* make sure to recompile/reinstall `mini_racer` and `libv8-node` after OS upgrades (for example via `gem uninstall --all mini_racer libv8-node`)
+* make sure you are on the latest patch/teeny version of a supported Ruby branch
 
 ## Features
 
@@ -26,8 +34,8 @@ You can simply eval one or many JavaScript snippets in a shared context
 
 ```ruby
 context = MiniRacer::Context.new
-context.eval 'var adder = (a,b)=>a+b;'
-puts context.eval 'adder(20,22)'
+context.eval("var adder = (a,b)=>a+b;")
+puts context.eval("adder(20,22)")
 # => 42
 ```
 
@@ -38,20 +46,20 @@ You can attach one or many ruby proc that can be accessed via JavaScript
 ```ruby
 context = MiniRacer::Context.new
 context.attach("math.adder", proc{|a,b| a+b})
-puts context.eval 'math.adder(20,22)'
+puts context.eval("math.adder(20,22)")
 # => 42
 ```
 
 ```ruby
 context = MiniRacer::Context.new
 context.attach("array_and_hash", proc{{a: 1, b: [1, {a: 1}]}})
-puts context.eval 'array_and_hash()'
+puts context.eval("array_and_hash()")
 # => {"a" => 1, "b" => [1, {"a" => 1}]}
 ```
 
 ### GIL free JavaScript execution
 
-The Ruby Global interpreter lock is released when scripts are executing
+The Ruby Global interpreter lock is released when scripts are executing:
 
 ```ruby
 context = MiniRacer::Context.new
@@ -59,35 +67,34 @@ Thread.new do
   sleep 1
   context.stop
 end
-context.eval 'while(true){}'
+context.eval("while(true){}")
 # => exception is raised
 ```
 
 This allows you to execute multiple scripts in parallel.
 
-### Timeout support
+### Timeout Support
 
 Contexts can specify a default timeout for scripts
 
 ```ruby
-# times out after 1 second (1000 ms)
 context = MiniRacer::Context.new(timeout: 1000)
-context.eval 'while(true){}'
-# => exception is raised
+context.eval("while(true){}")
+# => exception is raised after 1 second (1000 ms)
 ```
 
-### Memory softlimit support
+### Memory softlimit Support
 
 Contexts can specify a memory softlimit for scripts
 
 ```ruby
 # terminates script if heap usage exceeds 200mb after V8 garbage collection has run
-context = MiniRacer::Context.new(max_memory: 200000000)
-context.eval 'var a = new Array(10000); while(true) {a = a.concat(new Array(10000)); print("loop " + a.length);}'
+context = MiniRacer::Context.new(max_memory: 200_000_000)
+context.eval("var a = new Array(10000); while(true) {a = a.concat(new Array(10000)) }")
 # => V8OutOfMemoryError is raised
 ```
 
-### Object marshal max stackdepth support
+### Object marshal max Stack Ddepth Support
 
 Contexts can specify a stack depth limit for object marshalling. Max depth is unbounded by default.
 
@@ -100,23 +107,24 @@ context.eval("let arr = []; arr.push(arr); a(arr)")
 # => RuntimeError is raised
 ```
 
-### Rich debugging with "filename" support
+### Rich Debugging with File Name in Stack Trace Support
+
+You can provide `filename:` to `#eval` which will be used in stack traces produced by V8:
 
 ```ruby
-
 context = MiniRacer::Context.new
-context.eval('var foo = function() {bar();}', filename: 'a/foo.js')
-context.eval('bar()', filename: 'a/bar.js')
+context.eval("var foo = function() {bar();}", filename: "a/foo.js")
+context.eval("bar()", filename: "a/bar.js")
 
-# MiniRacer::RuntimeError is raised containing the filenames you specified for evals in backtrace
-
+# JavaScript at a/bar.js:1:1: ReferenceError: bar is not defined (MiniRacer::RuntimeError)
+# …
 ```
 
-### Fork safety
+### Fork Safety
 
 Some Ruby web servers employ forking (for example unicorn or puma in clustered mode). V8 is not fork safe by default and sadly Ruby does not have support for fork notifications per [#5446](https://bugs.ruby-lang.org/issues/5446).
 
-Since 0.6.1 mini_racer does support V8 single threaded platform mode which should remove most forking related issues. To enable run this before using `MiniRacer::Context`:
+Since 0.6.1 mini_racer does support V8 single threaded platform mode which should remove most forking related issues. To enable run this before using `MiniRacer::Context`, for example in a Rails initializer:
 
 ```ruby
 MiniRacer::Platform.set_flags!(:single_threaded)
@@ -124,16 +132,13 @@ MiniRacer::Platform.set_flags!(:single_threaded)
 
 If you want to ensure your application does not leak memory after fork either:
 
-1. Ensure no `MiniRacer::Context` objects are created in the master process
-
-Or
-
+1. Ensure no `MiniRacer::Context` objects are created in the master process; or
 2. Dispose manually of all `MiniRacer::Context` objects prior to forking
 
 ```ruby
 # before fork
 
-require 'objspace'
+require "objspace"
 ObjectSpace.each_object(MiniRacer::Context){|c| c.dispose}
 
 # fork here
@@ -144,9 +149,8 @@ ObjectSpace.each_object(MiniRacer::Context){|c| c.dispose}
 Context usage is threadsafe
 
 ```ruby
-
 context = MiniRacer::Context.new
-context.eval('counter=0; plus=()=>counter++;')
+context.eval("counter=0; plus=()=>counter++;")
 
 (1..10).map do
   Thread.new {
@@ -156,7 +160,6 @@ end.each(&:join)
 
 puts context.eval("counter")
 # => 10
-
 ```
 
 ### Snapshots
@@ -164,46 +167,40 @@ puts context.eval("counter")
 Contexts can be created with pre-loaded snapshots:
 
 ```ruby
-
-snapshot = MiniRacer::Snapshot.new('function hello() { return "world!"; }')
+snapshot = MiniRacer::Snapshot.new("function hello() { return 'world!'; }")
 
 context = MiniRacer::Context.new(snapshot: snapshot)
 
 context.eval("hello()")
 # => "world!"
-
 ```
 
-Snapshots can come in handy for example if you want your contexts to be pre-loaded for effiency. It uses [V8 snapshots](http://v8project.blogspot.com/2015/09/custom-startup-snapshots.html) under the hood; see [this link](http://v8project.blogspot.com/2015/09/custom-startup-snapshots.html) for caveats using these, in particular:
+Snapshots can come in handy for example if you want your contexts to be pre-loaded for efficiency. It uses [V8 snapshots](http://v8project.blogspot.com/2015/09/custom-startup-snapshots.html) under the hood; see [this link](http://v8project.blogspot.com/2015/09/custom-startup-snapshots.html) for caveats using these, in particular:
 
-```
-There is an important limitation to snapshots: they can only capture V8’s
-heap. Any interaction from V8 with the outside is off-limits when creating the
-snapshot. Such interactions include:
-
- * defining and calling API callbacks (i.e. functions created via v8::FunctionTemplate)
- * creating typed arrays, since the backing store may be allocated outside of V8
-
-And of course, values derived from sources such as `Math.random` or `Date.now`
-are fixed once the snapshot has been captured. They are no longer really random
-nor reflect the current time.
-```
+> There is an important limitation to snapshots: they can only capture V8’s
+> heap. Any interaction from V8 with the outside is off-limits when creating the
+> snapshot. Such interactions include:
+>
+> * defining and calling API callbacks (i.e. functions created via v8::FunctionTemplate)
+> * creating typed arrays, since the backing store may be allocated outside of V8
+>
+> And of course, values derived from sources such as `Math.random` or `Date.now`
+> are fixed once the snapshot has been captured. They are no longer really random
+> nor reflect the current time.
 
 Also note that snapshots can be warmed up, using the `warmup!` method, which allows you to call functions which are otherwise lazily compiled to get them to compile right away; any side effect of your warm up code being then dismissed. [More details on warming up here](https://github.com/electron/electron/issues/169#issuecomment-76783481), and a small example:
 
 ```ruby
+snapshot = MiniRacer::Snapshot.new("var counter = 0; function hello() { counter++; return 'world! '; }")
 
-snapshot = MiniRacer::Snapshot.new('var counter = 0; function hello() { counter++; return "world! "; }')
-
-snapshot.warmup!('hello()')
+snapshot.warmup!("hello()")
 
 context = MiniRacer::Context.new(snapshot: snapshot)
 
-context.eval('hello()')
+context.eval("hello()")
 # => "world! 1"
-context.eval('counter')
+context.eval("counter")
 # => 1
-
 ```
 
 ### Shared isolates
@@ -211,7 +208,6 @@ context.eval('counter')
 By default, MiniRacer's contexts each have their own isolate (V8 runtime). For efficiency, it is possible to re-use an isolate across contexts:
 
 ```ruby
-
 isolate = MiniRacer::Isolate.new
 
 context1 = MiniRacer::Context.new(isolate: isolate)
@@ -228,7 +224,7 @@ The caveat with this is that a given isolate can only execute one context at a t
 Also, note that if you want to use shared isolates together with snapshots, you need to first create an isolate with that snapshot, and then create contexts from that isolate:
 
 ```ruby
-snapshot = MiniRacer::Snapshot.new('function hello() { return "world!"; }')
+snapshot = MiniRacer::Snapshot.new("function hello() { return 'world!'; }")
 
 isolate = MiniRacer::Isolate.new(snapshot)
 
@@ -252,7 +248,6 @@ isolate.idle_notification(100)
 
 # force V8 to perform a full GC
 isolate.low_memory_notification
-
 ```
 
 This can come in handy to force V8 GC runs for example in between requests if you use MiniRacer on a web application.
@@ -270,11 +265,13 @@ MiniRacer::Platform.set_flags! :noconcurrent_recompilation, max_inlining_levels:
 ```
 
 This can come in handy if you want to use MiniRacer with Unicorn, which doesn't seem to always appreciate V8's liberal use of threading:
+
 ```ruby
 MiniRacer::Platform.set_flags! :noconcurrent_recompilation, :noconcurrent_sweeping
 ```
 
 Or else to unlock experimental features in V8, for example tail recursion optimization:
+
 ```ruby
 MiniRacer::Platform.set_flags! :harmony
 
@@ -295,6 +292,7 @@ context = MiniRacer::Context.new
 context.eval js
 # => "foo"
 ```
+
 The same code without the harmony runtime flag results in a `MiniRacer::RuntimeError: RangeError: Maximum call stack size exceeded` exception.
 Please refer to http://node.green/ as a reference on other harmony features.
 
@@ -304,17 +302,18 @@ Note that runtime flags must be set before any other operation (e.g. creating a 
 
 Flags:
 
-- :expose_gc : Will expose `gc()` which you can run in JavaScript to issue a gc
-- :max_old_space_size : defaults to 1400 (megs) on 64 bit, you can restric memory usage by limiting this.
-- **NOTE TO READER** our documentation could be awesome we could be properly documenting all the flags, they are hugely useful, if you feel like documenting a few more, PLEASE DO, PRs are welcome.
+* `:expose_gc`: Will expose `gc()` which you can run in JavaScript to issue a GC run.
+* `:max_old_space_size`: defaults to 1400 (megs) on 64 bit, you can restrict memory usage by limiting this.
+
+**NOTE TO READER** our documentation could be awesome we could be properly documenting all the flags, they are hugely useful, if you feel like documenting a few more, PLEASE DO, PRs are welcome.
 
 ## Controlling memory
 
-When hosting v8 you may want to keep track of memory usage, use #heap_stats to get memory usage:
+When hosting v8 you may want to keep track of memory usage, use `#heap_stats` to get memory usage:
 
 ```ruby
-context = MiniRacer::Context.new(timeout: 5)
-context.eval("let a='testing';")
+context = MiniRacer::Context.new
+# use context
 p context.heap_stats
 # {:total_physical_size=>1280640,
 #  :total_heap_size_executable=>4194304,
@@ -323,27 +322,27 @@ p context.heap_stats
 #  :heap_size_limit=>1501560832}
 ```
 
-If you wish to dispose of a context before waiting on the GC use
+If you wish to dispose of a context before waiting on the GC use `#dispose`:
 
 ```ruby
-context = MiniRacer::Context.new(timeout: 5)
+context = MiniRacer::Context.new
 context.eval("let a='testing';")
 context.dispose
 context.eval("a = 2")
 # MiniRacer::ContextDisposedError
 
-# nothing works on the context from now on, its a shell waiting to be disposed
+# nothing works on the context from now on, it's a shell waiting to be disposed
 ```
 
 A MiniRacer context can also be dumped in a heapsnapshot file using `#write_heap_snapshot(file_or_io)`
 
 ```ruby
-context = MiniRacer::Context.new(timeout: 5)
-context.eval("let a='testing';")
+context = MiniRacer::Context.new
+# use context
 context.write_heap_snapshot("test.heapsnapshot")
 ```
 
-This file can then be loaded in the memory tab of the chrome dev console.
+This file can then be loaded in the "memory" tab of the [Chrome DevTools](https://developer.chrome.com/docs/devtools/memory-problems/heap-snapshots/#view_snapshots).
 
 ### Function call
 
@@ -351,30 +350,29 @@ This calls the function passed as first argument:
 
 ```ruby
 context = MiniRacer::Context.new
-context.eval('function hello(name) { return "Hello, " + name + "!" }')
-context.call('hello', 'George')
+context.eval("function hello(name) { return `Hello, ${name}!` }")
+context.call("hello", "George")
 # "Hello, George!"
 ```
 
-Performance is slightly better than running `eval('hello("George")')` since:
+Performance is slightly better than running `context.eval("hello('George')")` since:
 
- - compilation of eval'd string is avoided
- - function arguments don't need to be converted to JSON
+* compilation of eval'd string is avoided
+* function arguments don't need to be converted to JSON
 
 ## Performance
 
 The `bench` folder contains benchmark.
 
-### Benchmark minification of Discourse application.js (both minified and unminified)
+### Benchmark minification of Discourse application.js (both minified and non-minified)
 
 MiniRacer outperforms node when minifying assets via execjs.
 
-- MiniRacer version 0.1.9
-- node version 6.10
-- therubyracer version 0.12.2
+* MiniRacer version 0.1.9
+* node version 6.10
+* therubyracer version 0.12.2
 
-```
-
+```terminal
 $ bundle exec ruby bench.rb mini_racer
 Benching with mini_racer
 mini_racer minify discourse_app.js 9292.72063ms
@@ -411,78 +409,64 @@ MiniRacer can fully support source maps but must be configured correctly to do s
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'mini_racer'
+gem "mini_racer"
 ```
 
 And then execute:
 
-    $ bundle
+```terminal
+$ bundle
 
 Or install it yourself as:
 
-    $ gem install mini_racer
-
+```terminal
+$ gem install mini_racer
+```
 
 **Note** using v8.h and compiling MiniRacer requires a C++11 standard compiler, more specifically clang 3.5 (or later) or GCC 6.3 (or later).
-
-
-### Troubleshooting
-
-If you have a problem installing mini_racer, please consider the following steps:
-
-* make sure you try the latest released version of mini_racer
-* make sure you have Rubygems >= 3.2.13 and bundler >= 2.2.13 installed via `gem update --system`
-* if you are using bundler, make sure to have `PLATFORMS` set correctly in `Gemfile.lock` via `bundle lock --add-platform`
-* make sure to recompile/reinstall `mini_racer` and `libv8-node` after system upgrades (for example via `gem uninstall --all mini_racer libv8-node`)
-* make sure you are on the latest patch/teeny version of a supported Ruby branch
 
 ## Similar Projects
 
 ### therubyracer
 
-- https://github.com/cowboyd/therubyracer
-- Most comprehensive bridge available
-- Provides the ability to "eval" JavaScript
-- Provides the ability to invoke Ruby code from JavaScript
-- Hold references to JavaScript objects and methods in your Ruby code
-- Hold references to Ruby objects and methods in JavaScript code
-- Uses libv8, so installation is fast
-- Supports timeouts for JavaScript execution
-- Does not release global interpreter lock, so performance is constrained to a single thread
-- Currently (May 2016) only supports v8 version 3.16.14 (Released approx November 2013), plans to upgrade by July 2016
-- Supports execjs
-
+* https://github.com/cowboyd/therubyracer
+* Most comprehensive bridge available
+* Provides the ability to "eval" JavaScript
+* Provides the ability to invoke Ruby code from JavaScript
+* Hold references to JavaScript objects and methods in your Ruby code
+* Hold references to Ruby objects and methods in JavaScript code
+* Uses libv8, so installation is fast
+* Supports timeouts for JavaScript execution
+* Does not release global interpreter lock, so performance is constrained to a single thread
+* Currently (May 2016) only supports v8 version 3.16.14 (Released approx November 2013), plans to upgrade by July 2016
+* Supports execjs
 
 ### v8eval
 
-- https://github.com/sony/v8eval
-- Provides the ability to "eval" JavaScript using the latest V8 engine
-- Does not depend on the [libv8](https://github.com/cowboyd/libv8) gem, installation can take 10-20 mins as V8 needs to be downloaded and compiled.
-- Does not release global interpreter lock when executing JavaScript
-- Does not allow you to invoke Ruby code from JavaScript
-- Multi runtime support due to SWIG based bindings
-- Supports a JavaScript debugger
-- Does not support timeouts for JavaScript execution
-- No support for execjs (can not be used with Rails uglifier and coffeescript gems)
-
+* https://github.com/sony/v8eval
+* Provides the ability to "eval" JavaScript using the latest V8 engine
+* Does not depend on the [libv8](https://github.com/cowboyd/libv8) gem, installation can take 10-20 mins as V8 needs to be downloaded and compiled.
+* Does not release global interpreter lock when executing JavaScript
+* Does not allow you to invoke Ruby code from JavaScript
+* Multi runtime support due to SWIG based bindings
+* Supports a JavaScript debugger
+* Does not support timeouts for JavaScript execution
+* No support for execjs (can not be used with Rails uglifier and coffeescript gems)
 
 ### therubyrhino
 
-- https://github.com/cowboyd/therubyrhino
-- API compatible with therubyracer
-- Uses Mozilla's Rhino engine https://github.com/mozilla/rhino
-- Requires JRuby
-- Support for timeouts for JavaScript execution
-- Concurrent cause .... JRuby
-- Supports execjs
-
+* https://github.com/cowboyd/therubyrhino
+* API compatible with therubyracer
+* Uses Mozilla's Rhino engine https://github.com/mozilla/rhino
+* Requires JRuby
+* Support for timeouts for JavaScript execution
+* Concurrent cause .... JRuby
+* Supports execjs
 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/rubyjs/mini_racer. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
-
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MiniRacer
 
-[![Test](https://github.com/rubyjs/mini_racer/actions/workflows/ci.yml/badge.svg)](https://github.com/rubyjs/mini_racer/actions/workflows/ci.yml)
+[![Test](https://github.com/rubyjs/mini_racer/actions/workflows/ci.yml/badge.svg)](https://github.com/rubyjs/mini_racer/actions/workflows/ci.yml) ![Gem](https://img.shields.io/gem/v/mini_racer)
 
 Minimal, modern embedded V8 for Ruby.
 


### PR DESCRIPTION
I Fixed some typos and other nit-picky whitespace stuff in CHANGELOG.

I made a bit more changes to the README. I actually wanted to fix some typos and move the troubleshooting up based on issues opened by users having trouble installing mini_racer, but then I guess I got carried away and tried to make some more improvements 😁 

* fixed various typos, inconsistencies and extra whitespace
* I added a rubygem version "badge", because I saw quite a few bug reports not on the latest version, maybe this helps 🤞   ![Gem](https://img.shields.io/gem/v/mini_racer) 
* I also moved the troubleshooting section up quite a bit, also in hopes that this helps to minimize reported bugs, that are easily fixed by using the troubleshooting guide 🤞🤞
* fixed a formatting error I added in https://github.com/rubyjs/mini_racer/pull/268 🤦 
* the memory soft limit example was broken. A non-existing `print()` was called, but it wasn't needed to showcase the feature anyway so I just dropped that
* in the examples, I switched to ECMAScript's [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to show that mini_racer actually supports modern JS.
* I tried to add links to various things mentioned, like to the docs on how to load memory profiles into Chrome DevTools, etc.

Please let me know if that's too much in one go and I can split this up for easier review.