### PR TITLE
Remove unneeded files from release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,6 @@ FROM ruby:${RUBY_VERSION}
 
 RUN test ! -f /etc/alpine-release || apk add --no-cache build-base git
 
-# without this `COPY .git`, we get the following error:
-#   fatal: not a git repository (or any of the parent directories): .git
-# but with it we need the full gem just to compile the extension because
-# of gemspec's `git --ls-files`
-# COPY .git /code/.git
 COPY Gemfile mini_racer.gemspec /code/
 COPY lib/mini_racer/version.rb /code/lib/mini_racer/version.rb
 WORKDIR /code

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/discourse/mini_racer/tree/v#{spec.version}",
   }
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\.github|bin|benchmark|test|spec|features|examples)/}) }
+  spec.files         = Dir["lib/**/*", "ext/**/*", "README.md", "LICENSE.txt", "CHANGELOG", "CODE_OF_CONDUCT.md"]
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/discourse/mini_racer/tree/v#{spec.version}",
   }
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(benchmark|test|spec|features|examples)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\.github|bin|benchmark|test|spec|features|examples)/}) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
I noticed that we include `.github/` and `bin/` when building. And other things :)

I think we can simplify this, by only including what we need, which is `lib/**/*` and `ext/**/*`. Additionally we probably want to continue to pack README, license, changelog and CoC.

**before** (released 0.6.4)

```
.
├── CHANGELOG
├── CODE_OF_CONDUCT.md
├── Dockerfile
├── Gemfile
├── LICENSE.txt
├── README.md
├── Rakefile
├── bin
│   ├── console
│   └── setup
├── ext
│   ├── mini_racer_extension
│   │   ├── Makefile
│   │   ├── extconf.rb
│   │   └── mini_racer_extension.cc
│   └── mini_racer_loader
│       ├── Makefile
│       ├── extconf.rb
│       └── mini_racer_loader.c
├── lib
│   ├── mini_racer
│   │   ├── truffleruby.rb
│   │   └── version.rb
│   ├── mini_racer.rb
│   ├── mini_racer_extension.bundle
│   └── mini_racer_loader.bundle
└── mini_racer.gemspec
```

**after** (build from `master`):

```
.
├── CHANGELOG
├── CODE_OF_CONDUCT.md
├── LICENSE.txt
├── README.md
├── ext
│   ├── mini_racer_extension
│   │   ├── Makefile
│   │   ├── extconf.rb
│   │   └── mini_racer_extension.cc
│   └── mini_racer_loader
│       ├── Makefile
│       ├── extconf.rb
│       └── mini_racer_loader.c
└── lib
    ├── mini_racer
    │   ├── truffleruby.rb
    │   └── version.rb
    ├── mini_racer.rb
    ├── mini_racer_extension.bundle
    └── mini_racer_loader.bundle
```