### PR TITLE
Adds dependabot config for updating Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Look for updates to Github Action modules once a week
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
We're not using a bunch of actions, but when they get updated, it would be nice to get a PR automatically once a week for us to review and merge.