### PR TITLE
gemspec: Exclude *.bundle (follow-up #281)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+CLEAN.add("{ext,lib}/**/*.{o,so,bundle}", "pkg")
+CLOBBER.add("Gemfile.lock")
+
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
@@ -24,7 +27,6 @@ else
   Rake::ExtensionTask.new( 'mini_racer_loader', gem )
   Rake::ExtensionTask.new( 'mini_racer_extension', gem )
 end
-
 
 
 # via http://blog.flavorjon.es/2009/06/easily-valgrind-gdb-your-ruby-c.html

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/discourse/mini_racer/tree/v#{spec.version}",
   }
 
-  spec.files         = Dir["lib/**/*", "ext/**/*", "README.md", "LICENSE.txt", "CHANGELOG", "CODE_OF_CONDUCT.md"].reject { |fn| File.fnmatch?("**/*.bundle}", fn, File::FNM_EXTGLOB) }
+  spec.files         = Dir["lib/**/*.rb", "ext/**/*", "README.md", "LICENSE.txt", "CHANGELOG", "CODE_OF_CONDUCT.md"]
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/discourse/mini_racer/tree/v#{spec.version}",
   }
 
-  spec.files         = Dir["lib/**/*", "ext/**/*", "README.md", "LICENSE.txt", "CHANGELOG", "CODE_OF_CONDUCT.md"].reject { |fn| File.fnmatch?("**/*.{bundle,c,cc}", fn, File::FNM_EXTGLOB) }
+  spec.files         = Dir["lib/**/*", "ext/**/*", "README.md", "LICENSE.txt", "CHANGELOG", "CODE_OF_CONDUCT.md"].reject { |fn| File.fnmatch?("**/*.bundle}", fn, File::FNM_EXTGLOB) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/discourse/mini_racer/tree/v#{spec.version}",
   }
 
-  spec.files         = Dir["lib/**/*", "ext/**/*", "README.md", "LICENSE.txt", "CHANGELOG", "CODE_OF_CONDUCT.md"]
+  spec.files         = FileList["lib/**/*", "ext/**/*", "README.md", "LICENSE.txt", "CHANGELOG", "CODE_OF_CONDUCT.md"].exclude("**/*.bundle", "**/*.{c,cc}")
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/discourse/mini_racer/tree/v#{spec.version}",
   }
 
-  spec.files         = FileList["lib/**/*", "ext/**/*", "README.md", "LICENSE.txt", "CHANGELOG", "CODE_OF_CONDUCT.md"].exclude("**/*.bundle", "**/*.{c,cc}")
+  spec.files         = Dir["lib/**/*", "ext/**/*", "README.md", "LICENSE.txt", "CHANGELOG", "CODE_OF_CONDUCT.md"].reject { |fn| File.fnmatch?("**/*.{bundle,c,cc}", fn, File::FNM_EXTGLOB) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Follow-Up for https://github.com/rubyjs/mini_racer/pull/281
Addresses https://github.com/rubyjs/mini_racer/pull/283#issuecomment-1572578821

I don't quite fully understand why this breaks, but building locally using `bundle exec rake compile` broke with #281. It works fine in CI though, which might be worth investigating. What worked for me to fix this (please have a look @Fayti1703) is to make sure `*.bundle` files are excluded. With this `bundle install && bundle exec rake` works (compiles and runs tests).

My experience with native extensions is limited. __I'd appreciate hints how to make local compilation consistent with CI__.

-cc @Fayti1703
-cc @lloeki 