### PR TITLE
Updates for TruffleRuby 23.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - "macos-12"
           - "ubuntu-20.04"
         ruby:
-          - "truffleruby+graalvm-head"
+          - "truffleruby+graalvm"
 
     name: ${{ matrix.os }} - ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
@@ -31,7 +31,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Install GraalVM JS component
-        run: gu install js
+        run: truffleruby-polyglot-get js
       - name: Compile
         run: bundle exec rake compile
       - name: Test

--- a/lib/mini_racer/truffleruby.rb
+++ b/lib/mini_racer/truffleruby.rb
@@ -72,8 +72,7 @@ module MiniRacer
 
       unless Polyglot.languages.include? "js"
         raise "The language 'js' is not available, you likely need to `export TRUFFLERUBYOPT='--jvm --polyglot'`\n" \
-          "You also need to install the 'js' component with 'gu install js' on GraalVM 22.2+\n" \
-          "Note that you need TruffleRuby+GraalVM and not just the TruffleRuby standalone to use MiniRacer"
+          "You also need to install the 'js' component, see https://github.com/oracle/truffleruby/blob/master/doc/user/polyglot.md#installing-other-languages"
       end
 
       @context = Polyglot::InnerContext.new(on_cancelled: -> { 


### PR DESCRIPTION
The way to install GraalJS changed, and this is now documented in TruffleRuby docs.