### PR TITLE
CI: Add macos-{13,14} and as well as Ruby 3.3 to matrix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-11"
+          - "macos-11" # deprecated by GitHub
           - "macos-12"
+          - "macos-13"
+          - "macos-14" # arm64
           - "ubuntu-20.04"
         ruby:
           - "truffleruby+graalvm"
@@ -43,12 +45,15 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-11"
+          - "macos-11" # deprecated by GitHub
           - "macos-12"
+          - "macos-13"
+          - "macos-14" # arm64
         ruby:
-          - "ruby-3.0"
+          - "ruby-3.0" # EOL as of 2024-04-23
           - "ruby-3.1"
           - "ruby-3.2"
+          - "ruby-3.3"
 
     name: ${{ matrix.os }} - ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
@@ -69,9 +74,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "3.0"
+          - "3.0" # EOL as of 2024-04-23
           - "3.1"
           - "3.2"
+          - "3.3"
         platform:
           - "amd64"
           - "arm64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,48 +7,49 @@ on:
       - main
 
 jobs:
-  test-truffleruby:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - "macos-11" # deprecated by GitHub
-          - "macos-12"
-          - "macos-13"
-          - "macos-14" # arm64
-          - "ubuntu-20.04"
-        ruby:
-          - "truffleruby+graalvm"
+  # test-truffleruby:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os:
+  #         - "macos-11" # deprecated by GitHub
+  #         - "macos-12"
+  #         - "macos-13"
+  #         - "macos-14" # arm64
+  #         - "ubuntu-20.04"
+  #       ruby:
+  #         - "truffleruby+graalvm"
 
-    name: ${{ matrix.os }} - ${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}
+  #   name: ${{ matrix.os }} - ${{ matrix.ruby }}
+  #   runs-on: ${{ matrix.os }}
 
-    env:
-      TRUFFLERUBYOPT: "--jvm --polyglot"
+  #   env:
+  #     TRUFFLERUBYOPT: "--jvm --polyglot"
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler: latest # to get this fix: https://github.com/rubygems/rubygems/issues/6165
-          bundler-cache: true
-      - name: Install GraalVM JS component
-        run: truffleruby-polyglot-get js
-      - name: Compile
-        run: bundle exec rake compile
-      - name: Test
-        run: bundle exec rake test
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ruby/setup-ruby@v1
+  #       with:
+  #         ruby-version: ${{ matrix.ruby }}
+  #         bundler: latest # to get this fix: https://github.com/rubygems/rubygems/issues/6165
+  #         bundler-cache: true
+  #     - name: Install GraalVM JS component
+  #       run: truffleruby-polyglot-get js
+  #     - name: Compile
+  #       run: bundle exec rake compile
+  #     - name: Test
+  #       run: bundle exec rake test
 
   test-darwin:
     strategy:
       fail-fast: false
       matrix:
         os:
-          - "macos-11" # deprecated by GitHub
-          - "macos-12"
-          - "macos-13"
-          - "macos-14" # arm64
+          # - "macos-11" # deprecated by GitHub
+          # - "macos-12"
+          # - "macos-13"
+          # - "macos-14" # arm64
+          - "macos-14-large"
         ruby:
           - "ruby-3.0" # EOL as of 2024-04-23
           - "ruby-3.1"
@@ -69,56 +70,56 @@ jobs:
       - name: Test
         run: bundle exec rake test
 
-  test-linux:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby:
-          - "3.0" # EOL as of 2024-04-23
-          - "3.1"
-          - "3.2"
-          - "3.3"
-        platform:
-          - "amd64"
-          - "arm64"
-        libc:
-          - "gnu"
-          - "musl"
+  # test-linux:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       ruby:
+  #         - "3.0" # EOL as of 2024-04-23
+  #         - "3.1"
+  #         - "3.2"
+  #         - "3.3"
+  #       platform:
+  #         - "amd64"
+  #         - "arm64"
+  #       libc:
+  #         - "gnu"
+  #         - "musl"
 
-    name: linux-${{ matrix.platform }} - ruby-${{ matrix.ruby }} - ${{ matrix.libc }}
-    runs-on: ubuntu-20.04
+  #   name: linux-${{ matrix.platform }} - ruby-${{ matrix.ruby }} - ${{ matrix.libc }}
+  #   runs-on: ubuntu-20.04
 
-    steps:
-      - name: Enable ${{ matrix.platform }} platform
-        id: qemu
-        if: ${{ matrix.platform != 'amd64' }}
-        run: |
-          docker run --privileged --rm tonistiigi/binfmt:latest --install ${{ matrix.platform }} | tee platforms.json
-      - name: Start container
-        id: container
-        run: |
-          case ${{ matrix.libc }} in
-            gnu)
-              echo 'ruby:${{ matrix.ruby }}'
-              ;;
-            musl)
-              echo 'ruby:${{ matrix.ruby }}-alpine'
-              ;;
-          esac > container_image
-          echo "image=$(cat container_image)" >> $GITHUB_OUTPUT
-          docker run --rm -d -v "${PWD}":"${PWD}" -w "${PWD}" --platform linux/${{ matrix.platform }} $(cat container_image) /bin/sleep 64d | tee container_id
-          docker exec -w "${PWD}" $(cat container_id) uname -a
-          echo "container_id=$(cat container_id)" >> $GITHUB_OUTPUT
-      - name: Install Alpine system dependencies
-        if: ${{ matrix.libc == 'musl' }}
-        run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} apk add --no-cache build-base bash git
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Update Rubygems
-        run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} gem update --system
-      - name: Bundle
-        run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} bundle install
-      - name: Compile
-        run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} bundle exec rake compile
-      - name: Test
-        run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} bundle exec rake test
+  #   steps:
+  #     - name: Enable ${{ matrix.platform }} platform
+  #       id: qemu
+  #       if: ${{ matrix.platform != 'amd64' }}
+  #       run: |
+  #         docker run --privileged --rm tonistiigi/binfmt:latest --install ${{ matrix.platform }} | tee platforms.json
+  #     - name: Start container
+  #       id: container
+  #       run: |
+  #         case ${{ matrix.libc }} in
+  #           gnu)
+  #             echo 'ruby:${{ matrix.ruby }}'
+  #             ;;
+  #           musl)
+  #             echo 'ruby:${{ matrix.ruby }}-alpine'
+  #             ;;
+  #         esac > container_image
+  #         echo "image=$(cat container_image)" >> $GITHUB_OUTPUT
+  #         docker run --rm -d -v "${PWD}":"${PWD}" -w "${PWD}" --platform linux/${{ matrix.platform }} $(cat container_image) /bin/sleep 64d | tee container_id
+  #         docker exec -w "${PWD}" $(cat container_id) uname -a
+  #         echo "container_id=$(cat container_id)" >> $GITHUB_OUTPUT
+  #     - name: Install Alpine system dependencies
+  #       if: ${{ matrix.libc == 'musl' }}
+  #       run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} apk add --no-cache build-base bash git
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Update Rubygems
+  #       run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} gem update --system
+  #     - name: Bundle
+  #       run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} bundle install
+  #     - name: Compile
+  #       run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} bundle exec rake compile
+  #     - name: Test
+  #       run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} bundle exec rake test


### PR DESCRIPTION
As per the current policy we could/should drop Ruby 3.0 (as it is EOL as of 2024-04-23). But maybe we can keep it in the CI if it doesn't cause issues. Thoughts?

I also added `macos-13` and `macos-14`, whereas `macos-14` is running on Apple Silicon M1. Before, we had no builds running on darwin-arm, which is a gap that should be closed IMO. `macos-14-large` runs on x86, but is not free.

FYI: GitHub has deprecated `macos-11` runner images (Big Sur, released Nov 2020). According to https://github.com/actions/runner-images/issues/9255 it is planned to remove it in Q2 2024. `macos-12` is going to be deprecated in Q3 and removed in Q4.