### PR TITLE
CI:  Remove macos-11 from CI as this is no longer available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-11" # deprecated by GitHub
           - "macos-12"
           - "macos-13"
           - "macos-14" # arm64
@@ -52,7 +51,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-11" # deprecated by GitHub
           - "macos-12"
           - "macos-13"
           - "macos-14" # arm64


### PR DESCRIPTION
macOS 11 (BigSur, initial release 2020) was removed end of last month, see https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal and also https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/.