### PR TITLE
FIX: skip mini_racer_loader when malloc is overridden

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+- 0.14.1 - 14-08-2024
+
+  - No longer use mini_racer_loader if LD_PRELOAD is defined and adds a malloc provider. This resolves segfaults when people LD_PRELOAD jemalloc or tcmalloc.
 
 - 0.14.0 - 06-08-2024
 

--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -4,14 +4,23 @@ require "pathname"
 if RUBY_ENGINE == "truffleruby"
   require "mini_racer/truffleruby"
 else
-  require "mini_racer_loader" 
-  ext_filename = "mini_racer_extension.#{RbConfig::CONFIG['DLEXT']}"
-  ext_path = Gem.loaded_specs['mini_racer'].require_paths
-    .map { |p| (p = Pathname.new(p)).absolute? ? p : Pathname.new(__dir__).parent + p }
-  ext_found = ext_path.map { |p| p + ext_filename }.find { |p| p.file? }
+  if ENV["LD_PRELOAD"].to_s.include?("malloc")
+    require "mini_racer_extension"
+  else
+    require "mini_racer_loader"
+    ext_filename = "mini_racer_extension.#{RbConfig::CONFIG["DLEXT"]}"
+    ext_path =
+      Gem.loaded_specs["mini_racer"].require_paths.map do |p|
+        (p = Pathname.new(p)).absolute? ? p : Pathname.new(__dir__).parent + p
+      end
+    ext_found = ext_path.map { |p| p + ext_filename }.find { |p| p.file? }
 
-  raise LoadError, "Could not find #{ext_filename} in #{ext_path.map(&:to_s)}" unless ext_found
-  MiniRacer::Loader.load(ext_found.to_s)
+    unless ext_found
+      raise LoadError,
+            "Could not find #{ext_filename} in #{ext_path.map(&:to_s)}"
+    end
+    MiniRacer::Loader.load(ext_found.to_s)
+  end
 end
 
 require "thread"

--- a/lib/mini_racer/version.rb
+++ b/lib/mini_racer/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module MiniRacer
-  VERSION = "0.14.0"
+  VERSION = "0.14.1"
   LIBV8_NODE_VERSION = "~> 18.19.0.0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'mini_racer'
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "mini_racer"
 
-require 'minitest/pride'
-require 'minitest/autorun'
+require "minitest/autorun"


### PR DESCRIPTION
LD_PRELOAD can potentially cause issues with the "symbols hidden" loader for mini_racer

This will unconditionally skip the loader when LD_PRELOAD is specified and points to *malloc (eg jemalloc or tcmalloc)

see: https://github.com/rubyjs/mini_racer/issues/292#issuecomment-1835646792