### PR TITLE
Fix "can't alloc thread" exception on exit

### DIFF
--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -316,6 +316,7 @@ module MiniRacer
       @last_eval = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       @ensure_gc_mutex.synchronize do
         @ensure_gc_thread = nil if !@ensure_gc_thread&.alive?
+        return if !Thread.main.alive? # avoid "can't alloc thread" exception
         @ensure_gc_thread ||= Thread.new do
           ensure_gc_after_idle_seconds = @ensure_gc_after_idle / 1000.0
           done = false


### PR DESCRIPTION
It's no longer possible to create new threads once Ruby's main thread has exited.

<hr>

Specifically, it works around this: https://github.com/ruby/ruby/blob/abc04e898b/thread.c#L900-L902