### PR TITLE
Fix -Wold-style-definition compiler warning

### DIFF
--- a/ext/mini_racer_loader/mini_racer_loader.c
+++ b/ext/mini_racer_loader/mini_racer_loader.c
@@ -115,7 +115,7 @@ failed:
     rb_raise(rb_eLoadError, "%s", error);
 }
 
-__attribute__((visibility("default"))) void Init_mini_racer_loader()
+__attribute__((visibility("default"))) void Init_mini_racer_loader(void)
 {
     VALUE mMiniRacer = rb_define_module("MiniRacer");
     VALUE mLoader = rb_define_module_under(mMiniRacer, "Loader");


### PR DESCRIPTION
`int f()` in C is a variadic function (taking any number of arguments), not a function taking no arguments, like it is in C++.