### PR TITLE
Disable strict aliasing

### DIFF
--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -19,6 +19,9 @@ $CXXFLAGS += " -rdynamic" unless $CXXFLAGS.split.include? "-rdynamic"
 $CXXFLAGS += " -fPIC" unless $CXXFLAGS.split.include? "-rdynamic" or IS_DARWIN
 $CXXFLAGS += " -std=c++17"
 $CXXFLAGS += " -fpermissive"
+$CXXFLAGS += " -fno-rtti"
+$CXXFLAGS += " -fno-exceptions"
+$CXXFLAGS += " -fno-strict-aliasing"
 #$CXXFLAGS += " -DV8_COMPRESS_POINTERS"
 $CXXFLAGS += " -fvisibility=hidden "
 


### PR DESCRIPTION
Harmonize C++ compiler flags with Node.js (-fno-rtti, -fno-exceptions) and, critically, disable strict aliasing, because V8 is not the least bit strict-aliasing safe.

Upstream turned it off in https://github.com/nodejs/node/pull/54339, like it always should have been, and I suspect the mismatch may be the cause of segfaults that show up in production.

~~Remove -fpermissive, it's not needed and something to discourage.~~