### PR TITLE
Fix crash on invalid date object

### DIFF
--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -252,6 +252,16 @@ class MiniRacerTest < Minitest::Test
     )
   end
 
+  def test_date_nan
+    # NoMethodError: undefined method `source_location' for "<internal:core>
+    # core/float.rb:114:in `to_i'":Thread::Backtrace::Location
+    if RUBY_ENGINE == "truffleruby"
+      skip "TruffleRuby bug"
+    end
+    context = MiniRacer::Context.new
+    context.eval("new Date(NaN)") # should not crash process
+  end
+
   def test_return_date
     context = MiniRacer::Context.new
     test_time = Time.new


### PR DESCRIPTION
mini_racer converts JS objects to Ruby objects. Ruby's C API functions call rb_raise() on invalid inputs, and rb_raise() in turn is a glorified longjmp() that jumps up the stack.

Longjmp and C++ destructors do not play well together. It left V8 in an undefined state, resulting in random "Disposing the isolate that is entered by a thread" fatal errors.

Fixes: https://github.com/rubyjs/mini_racer/issues/316

<hr>

Easiest to review with `?w=1` ([link](https://github.com/rubyjs/mini_racer/pull/317/files?w=1)), the bulk is whitespace change because of an extra level of indent.

The title says "invalid date object" but this pull request  in fact addresses a wider range of bugs around value conversion.

There is at least one other instance around JSON parsing. I'll open another PR for that.