### PR TITLE
Fix segfault, handle symbol conversion correctly

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -565,6 +565,7 @@ static VALUE convert_v8_to_ruby(Isolate* isolate, Local<Context> context,
 
     Isolate::Scope isolate_scope(isolate);
     HandleScope scope(isolate);
+    Context::Scope context_scope(context);
 
     StackCounter stackCounter(isolate);
 
@@ -672,8 +673,9 @@ static VALUE convert_v8_to_ruby(Isolate* isolate, Local<Context> context,
         }
 
         if (value->IsSymbol()) {
-            v8::String::Utf8Value symbol_name(isolate,
-            Local<Symbol>::Cast(value)->Description(isolate));
+            Local<Symbol> symbol = Local<Symbol>::Cast(value);
+            Local<Value> description = symbol->Description(isolate);
+            v8::String::Utf8Value symbol_name(isolate, description);
 
             VALUE str_symbol = rb_utf8_str_new(*symbol_name, symbol_name.length());
 

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -975,6 +975,7 @@ class MiniRacerTest < Minitest::Test
   def test_symbol_support
     context = MiniRacer::Context.new()
     assert_equal :foo, context.eval("Symbol('foo')")
+    assert_equal :undefined, context.eval("Symbol()") # should not crash
   end
 
   def test_cyclical_object_js


### PR DESCRIPTION
Symbol::Description() normally returns a string, but when the symbol does not have a description, it returns undefined.

The String::Utf8Value constructor requires that a v8::Context is active for the ToString operation it executes. ToString is a no-op for strings (hence no crash) but not for undefined.

Add a Context::Scope to fix that.

Fixes: https://github.com/rubyjs/mini_racer/issues/318