### PR TITLE
Handle DataCloneError serialization errors

### DIFF
--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -893,14 +893,13 @@ class MiniRacerTest < Minitest::Test
       skip "TruffleRuby does not support WebAssembly"
     end
     context = MiniRacer::Context.new
-    # Error: [object Object] could not be cloned
-    assert_raises(MiniRacer::RuntimeError) do
-      context.eval("
-        var b = [0,97,115,109,1,0,0,0,1,26,5,80,0,95,0,80,0,95,1,127,0,96,0,1,110,96,1,100,2,1,111,96,0,1,100,3,3,4,3,3,2,4,7,26,2,12,99,114,101,97,116,101,83,116,114,117,99,116,0,1,7,114,101,102,70,117,110,99,0,2,9,5,1,3,0,1,0,10,23,3,8,0,32,0,20,2,251,27,11,7,0,65,12,251,0,1,11,4,0,210,0,11,0,44,4,110,97,109,101,1,37,3,0,11,101,120,112,111,114,116,101,100,65,110,121,1,12,99,114,101,97,116,101,83,116,114,117,99,116,2,7,114,101,102,70,117,110,99]
-        var o = new WebAssembly.Instance(new WebAssembly.Module(new Uint8Array(b))).exports
-        o.refFunc()(o.createStruct) // exotic object
-      ")
-    end
+    expected = {"error" => "Error: [object Object] could not be cloned."}
+    actual = context.eval("
+      var b = [0,97,115,109,1,0,0,0,1,26,5,80,0,95,0,80,0,95,1,127,0,96,0,1,110,96,1,100,2,1,111,96,0,1,100,3,3,4,3,3,2,4,7,26,2,12,99,114,101,97,116,101,83,116,114,117,99,116,0,1,7,114,101,102,70,117,110,99,0,2,9,5,1,3,0,1,0,10,23,3,8,0,32,0,20,2,251,27,11,7,0,65,12,251,0,1,11,4,0,210,0,11,0,44,4,110,97,109,101,1,37,3,0,11,101,120,112,111,114,116,101,100,65,110,121,1,12,99,114,101,97,116,101,83,116,114,117,99,116,2,7,114,101,102,70,117,110,99]
+      var o = new WebAssembly.Instance(new WebAssembly.Module(new Uint8Array(b))).exports
+      o.refFunc()(o.createStruct) // exotic object
+    ")
+    assert_equal expected, actual
   end
 
   def test_proxy_support
@@ -1060,16 +1059,17 @@ class MiniRacerTest < Minitest::Test
 
   def test_regexp_string_iterator
     context = MiniRacer::Context.new
-    exc = false
-    begin
-      context.eval("'abc'.matchAll(/./g)")
-    rescue MiniRacer::RuntimeError => e
-      # TODO(bnoordhuis) maybe detect the iterator object and serialize
-      # it as an array of strings; problem is there is no V8 API to detect
-      # regexp string iterator objects
-      assert_match(/\[object RegExp String Iterator\] could not be cloned/, e.message)
-      exc = true
-    end
-    assert exc
+    # TODO(bnoordhuis) maybe detect the iterator object and serialize
+    # it as a string or array of strings; problem is there is no V8 API
+    # to detect regexp string iterator objects
+    expected = {"error" => "Error: [object RegExp String Iterator] could not be cloned."}
+    assert_equal expected, context.eval("'abc'.matchAll(/./g)")
+  end
+
+  def test_function_property
+    context = MiniRacer::Context.new
+    # regrettably loses the non-function properties
+    expected = {"error" => "Error: f() {} could not be cloned."}
+    assert_equal expected, context.eval("({ x: 42, f() {} })")
   end
 end


### PR DESCRIPTION
Instead of trying to detect upfront if an object can be serialized, just do it and see if it throws a DataCloneError.

Unexpected DataCloneErrors were of course already being handled but the new approach does it in a centralized and generic manner.

Failed serialization now passes an object with a single "error" string property back to Ruby land.

Fixes the failing test from https://github.com/rubyjs/mini_racer/pull/329