### PR TITLE
Handle two-byte string alignment padding

### DIFF
--- a/ext/mini_racer_extension/serde.c
+++ b/ext/mini_racer_extension/serde.c
@@ -370,6 +370,7 @@ static int des1(char (*err)[64], const uint8_t **p, const uint8_t *pe,
 
     if (depth < 0)
         return bail(err, "too much recursion");
+again:
     if (*p >= pe)
         goto too_short;
     switch ((c = *(*p)++)) {
@@ -380,7 +381,9 @@ static int des1(char (*err)[64], const uint8_t **p, const uint8_t *pe,
             snprintf(*err, sizeof(*err), "bad tag: %02x", c);
         }
         return -1;
-    case '\0': // padding
+    case '\0': // skip alignment padding for two-byte strings
+        if (*p < pe)
+            goto again;
         break;
     case '^':
         if (r_varint(p, pe, &u))


### PR DESCRIPTION
For compatibility with old clients of the serializer wire format, V8 inserts a padding byte when a two-byte string is not 16 bits aligned, so skip those.

We don't have to emit padding ourselves, V8 handles unaligned strings just fine.

Messages can have an arbitrary amount of padding at the end. Skip that as well.

No test because hitting the right conditions in V8 is rather difficult and brittle.