### PR TITLE
Fix one-byte string Latin-1 to UTF-8 conversion

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.c
+++ b/ext/mini_racer_extension/mini_racer_extension.c
@@ -339,13 +339,24 @@ static VALUE str_encode_bang(VALUE v)
 
 static void des_string8(void *arg, const uint8_t *s, size_t n)
 {
+    rb_encoding *e;
     DesCtx *c;
     VALUE v;
 
     c = arg;
-    v = rb_enc_str_new((char *)s, n, rb_ascii8bit_encoding());
-    if (c->transcode_latin1)
+    if (*c->err)
+        return;
+    if (c->transcode_latin1) {
+        e = rb_enc_find("ISO-8859-1"); // TODO cache?
+        if (!e) {
+            snprintf(c->err, sizeof(c->err), "no ISO-8859-1 encoding");
+            return;
+        }
+        v = rb_enc_str_new((char *)s, n, e);
         v = str_encode_bang(v); // cannot fail
+    } else {
+        v = rb_enc_str_new((char *)s, n, rb_ascii8bit_encoding());
+    }
     put(c, v);
 }
 

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -1115,6 +1115,7 @@ class MiniRacerTest < Minitest::Test
 
   def test_string_encoding
     context = MiniRacer::Context.new
+    assert_equal "ä", context.eval("'ä'")
     assert_equal "ok", context.eval("'ok'".encode("ISO-8859-1"))
     assert_equal "ok", context.eval("'ok'".encode("ISO8859-1"))
     assert_equal "ok", context.eval("'ok'".encode("UTF-16LE"))


### PR DESCRIPTION
Ruby is not wrong to insist that an ASCII-8BIT string with a character that has its high bit set cannot be converted to UTF-8. Interpret such strings as ISO-8859-1 a.k.a. Latin-1 and only then convert to UTF-8.