### PR TITLE
Fix object serialization

### DIFF
--- a/ext/mini_racer_extension/mini_racer_v8.cc
+++ b/ext/mini_racer_extension/mini_racer_v8.cc
@@ -378,18 +378,7 @@ void v8_api_callback(const v8::FunctionCallbackInfo<v8::Value>& info)
     des.ReadHeader(st.context).Check();
     v8::Local<v8::Value> result;
     if (!des.ReadValue(st.context).ToLocal(&result)) return; // exception pending
-    v8::Local<v8::Object> response; // [result, err]
-    if (!result->ToObject(st.context).ToLocal(&response)) return;
-    v8::Local<v8::Value> err;
-    if (!response->Get(st.context, 1).ToLocal(&err)) return;
-    if (err->IsUndefined()) {
-        if (!response->Get(st.context, 0).ToLocal(&result)) return;
-        info.GetReturnValue().Set(result);
-    } else {
-        v8::Local<v8::String> message;
-        if (!err->ToString(st.context).ToLocal(&message)) return;
-        st.isolate->ThrowException(v8::Exception::Error(message));
-    }
+    info.GetReturnValue().Set(result);
 }
 
 // response is err or empty string

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -1126,4 +1126,13 @@ class MiniRacerTest < Minitest::Test
       assert_equal Encoding::UTF_16LE, context.eval("'ok\\uD800'").encoding
     end
   end
+
+  def test_object_ref
+    context = MiniRacer::Context.new
+    context.eval("function f(o) { return o }")
+    expected = {}
+    expected["a"] = expected["b"] = {"x" => 42}
+    actual = context.call("f", expected)
+    assert_equal actual, expected
+  end
 end


### PR DESCRIPTION
Use of ser_array_begin in two cases caused an off-by-one error in the object back-reference count that is used to stop an object from being encoded more than once (and thus maintains object identity, allowing recursive structures.)