### PR TITLE
Update to V8 12.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,8 @@ Or install it yourself as:
 $ gem install mini_racer
 ```
 
-**Note** using v8.h and compiling MiniRacer requires a C++11 standard compiler, more specifically clang 3.5 (or later) or GCC 6.3 (or later).
+**Note** using v8.h and compiling MiniRacer requires a C++20 capable compiler.
+gcc >= 12.2 and Xcode >= 13 are, at the time of writing, known to work.
 
 ## Similar Projects
 

--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -19,7 +19,7 @@ $CXXFLAGS += " -Wall" unless $CXXFLAGS.split.include? "-Wall"
 $CXXFLAGS += " -g" unless $CXXFLAGS.split.include? "-g"
 $CXXFLAGS += " -rdynamic" unless $CXXFLAGS.split.include? "-rdynamic"
 $CXXFLAGS += " -fPIC" unless $CXXFLAGS.split.include? "-rdynamic" or IS_DARWIN
-$CXXFLAGS += " -std=c++17"
+$CXXFLAGS += " -std=c++20"
 $CXXFLAGS += " -fpermissive"
 $CXXFLAGS += " -fno-rtti"
 $CXXFLAGS += " -fno-exceptions"
@@ -45,28 +45,6 @@ end
 if ENV['CXX']
   puts "SETTING CXX"
   CONFIG['CXX'] = ENV['CXX']
-end
-
-CXX11_TEST = <<EOS
-#if __cplusplus <= 199711L
-#   error A compiler that supports at least C++11 is required in order to compile this project.
-#endif
-EOS
-
-`echo "#{CXX11_TEST}" | #{CONFIG['CXX']} -std=c++0x -x c++ -E -`
-unless $?.success?
-  warn <<EOS
-
-
-WARNING: C++11 support is required for compiling mini_racer. Please make sure
-you are using a compiler that supports at least C++11. Examples of such
-compilers are GCC 4.7+ and Clang 3.2+.
-
-If you are using Travis, consider either migrating your build to Ubuntu Trusty or
-installing GCC 4.8. See mini_racer's README.md for more information.
-
-
-EOS
 end
 
 CONFIG['LDSHARED'] = '$(CXX) -shared' unless IS_DARWIN

--- a/ext/mini_racer_extension/mini_racer_extension.c
+++ b/ext/mini_racer_extension/mini_racer_extension.c
@@ -703,7 +703,6 @@ static void dispatch1(Context *c, const uint8_t *p, size_t n)
     case 'C': return v8_timedwait(c, p+1, n-1, v8_call);
     case 'E': return v8_timedwait(c, p+1, n-1, v8_eval);
     case 'H': return v8_heap_snapshot(c->pst);
-    case 'I': return v8_idle_notification(c->pst, p+1, n-1);
     case 'P': return v8_pump_message_loop(c->pst);
     case 'S': return v8_heap_stats(c->pst);
     case 'T': return v8_snapshot(c->pst, p+1, n-1);
@@ -1301,20 +1300,6 @@ static VALUE context_pump_message_loop(VALUE self)
     return rendezvous(c, &b); // takes ownership of |b|
 }
 
-static VALUE context_idle_notification(VALUE self, VALUE arg)
-{
-    Context *c;
-    Ser s;
-
-    Check_Type(arg, T_FIXNUM);
-    TypedData_Get_Struct(self, Context, &context_type, c);
-    // request is (I)dle notification, idle_time_in_seconds
-    ser_init1(&s, 'I');
-    ser_num(&s, LONG2FIX(arg) / 1e3);
-    // response is |undefined|
-    return rendezvous(c, &s.b); // takes ownership of |s.b|
-}
-
 static VALUE context_low_memory_notification(VALUE self)
 {
     Buf req, res;
@@ -1638,7 +1623,6 @@ void Init_mini_racer_extension(void)
     rb_define_method(c, "heap_stats", context_heap_stats, 0);
     rb_define_method(c, "heap_snapshot", context_heap_snapshot, 0);
     rb_define_method(c, "pump_message_loop", context_pump_message_loop, 0);
-    rb_define_method(c, "idle_notification", context_idle_notification, 1);
     rb_define_method(c, "low_memory_notification", context_low_memory_notification, 0);
     rb_define_alloc_func(c, context_alloc);
 

--- a/ext/mini_racer_extension/mini_racer_v8.cc
+++ b/ext/mini_racer_extension/mini_racer_v8.cc
@@ -834,26 +834,6 @@ fail:
     }
 }
 
-extern "C" void v8_idle_notification(State *pst, const uint8_t *p, size_t n)
-{
-    State& st = *pst;
-    v8::TryCatch try_catch(st.isolate);
-    v8::HandleScope handle_scope(st.isolate);
-    v8::ValueDeserializer des(st.isolate, p, n);
-    des.ReadHeader(st.context).Check();
-    double idle_time_in_seconds = .01;
-    {
-        v8::Local<v8::Value> idle_time_in_seconds_v;
-        if (!des.ReadValue(st.context).ToLocal(&idle_time_in_seconds_v)) goto fail;
-        if (!idle_time_in_seconds_v->NumberValue(st.context).To(&idle_time_in_seconds)) goto fail;
-    }
-fail:
-    double now = platform->MonotonicallyIncreasingTime();
-    bool stop = st.isolate->IdleNotificationDeadline(now + idle_time_in_seconds);
-    auto result = v8::Boolean::New(st.isolate, stop);
-    if (!reply(st, result)) abort();
-}
-
 extern "C" void v8_low_memory_notification(State *pst)
 {
     pst->isolate->LowMemoryNotification();

--- a/ext/mini_racer_extension/mini_racer_v8.h
+++ b/ext/mini_racer_extension/mini_racer_v8.h
@@ -45,7 +45,6 @@ void v8_heap_snapshot(struct State *pst);
 void v8_pump_message_loop(struct State *pst);
 void v8_snapshot(struct State *pst, const uint8_t *p, size_t n);
 void v8_warmup(struct State *pst, const uint8_t *p, size_t n);
-void v8_idle_notification(struct State *pst, const uint8_t *p, size_t n);
 void v8_low_memory_notification(struct State *pst);
 void v8_terminate_execution(struct State *pst); // called from ruby or watchdog thread
 void v8_single_threaded_enter(struct State *pst, struct Context *c, void (*f)(struct Context *c));

--- a/lib/mini_racer/truffleruby.rb
+++ b/lib/mini_racer/truffleruby.rb
@@ -67,10 +67,6 @@ module MiniRacer
       GC.start
     end
 
-    def idle_notification(idle_time)
-      true
-    end
-
     private
 
     @context_initialized = false

--- a/lib/mini_racer/version.rb
+++ b/lib/mini_racer/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module MiniRacer
-  VERSION = "0.17.0.pre13"
-  LIBV8_NODE_VERSION = "~> 22.7.0.4"
+  VERSION = "0.18.0.pre1"
+  LIBV8_NODE_VERSION = "~> 23.6.1.0"
 end

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -594,13 +594,6 @@ class MiniRacerTest < Minitest::Test
     assert_equal "function", context2.eval("typeof(Math.sin)")
   end
 
-  def test_isolate_can_be_notified_of_idle_time
-    context = MiniRacer::Context.new
-
-    # returns true if embedder should stop calling
-    assert(context.idle_notification(1000))
-  end
-
   def test_platform_set_flags_raises_an_exception_if_already_initialized
     # makes sure it's initialized
     MiniRacer::Snapshot.new


### PR DESCRIPTION
Removes context.idle_notification because the V8 API it uses has been removed with no real replacement.

V8 suggests to use Isolate::MemoryPressureNotification() instead but that's not really the same thing and overlaps significantly with context.low_memory_notification.

Remove the stale object marshalling section from the README.

<hr>

Needs a libv8-node release from its node-23 branch first