### PR TITLE
Handle termination exceptions during serialization

### DIFF
--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -1132,4 +1132,13 @@ class MiniRacerTest < Minitest::Test
     actual = context.call("f", expected)
     assert_equal actual, expected
   end
+
+  def test_termination_exception
+    context = MiniRacer::Context.new
+    a = Thread.new { context.stop while true }
+    b = Thread.new { context.heap_stats while true } # should not crash/abort
+    sleep 1.5
+    a.kill
+    b.kill
+  end
 end

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -302,6 +302,9 @@ class MiniRacerTest < Minitest::Test
   end
 
   def test_datetime_missing
+    # NoMethodError: undefined method `source_location' for
+    # #<Thread::Backtrace::Location:0x4e88>
+    skip "TruffleRuby bug" if RUBY_ENGINE == "truffleruby"
     date_time_backup = Object.send(:remove_const, :DateTime)
 
     begin


### PR DESCRIPTION
Don't abort when the ruby thread calls `context.stop` right when the V8 thread is serializing its response to a request. Temporarily cancel the termination exception, retry serialization, and reraise the exception.