### PR TITLE
Convert big ruby integers to js bigints

### DIFF
--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -1153,5 +1153,19 @@ class MiniRacerTest < Minitest::Test
       assert_equal(result.class, big_int.class)
       assert_equal(result, big_int)
     }
+    types = []
+    [2**63/1024-1, 2**63/1024, -2**63/1024+1, -2**63/1024].each { |big_int|
+      context = MiniRacer::Context.new
+      context.attach("test", proc { big_int })
+      context.attach("type", proc { |arg| types.push(arg) })
+      result = context.eval("const t = test(); type(typeof t); t")
+      assert_equal(result.class, big_int.class)
+      assert_equal(result, big_int)
+    }
+    if RUBY_ENGINE == "truffleruby"
+      assert_equal(types, %w[number number number number])
+    else
+      assert_equal(types, %w[number bigint number bigint])
+    end
   end
 end


### PR DESCRIPTION
Numbers outside the range that double-precision floating-point numbers can represent exactly are now converted to JS BigInts instead of being rejected outright. Said range corresponds to `Number.MIN_SAFE_INTEGER` and `Number.MAX_SAFE_INTEGER` on the JS side.

Refs: https://github.com/rubyjs/mini_racer/issues/348