### PR TITLE
CI: Install tzdata for musl-based Ruby docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           echo "container_id=$(cat container_id)" >> $GITHUB_OUTPUT
       - name: Install Alpine system dependencies
         if: ${{ matrix.libc == 'musl' }}
-        run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} apk add --no-cache build-base bash git
+        run: docker exec -w "${PWD}" ${{ steps.container.outputs.container_id }} apk add --no-cache build-base bash git tzdata
       - name: Checkout
         uses: actions/checkout@v4
       - name: Update Rubygems

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
               ;;
           esac > container_image
           echo "image=$(cat container_image)" >> $GITHUB_OUTPUT
-          docker run --rm -d -v "${PWD}":"${PWD}" -w "${PWD}" $(cat container_image) /bin/sleep 64d | tee container_id
+          docker run --rm -d -v "${PWD}":"${PWD}" -w "${PWD}" -e VERBOSE_MINITEST=true $(cat container_image) /bin/sleep 64d | tee container_id
           docker exec -w "${PWD}" $(cat container_id) uname -a
           echo "container_id=$(cat container_id)" >> $GITHUB_OUTPUT
       - name: Install Alpine system dependencies

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ Minitest::TestTask.create(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_globs = FileList['test/**/*_test.rb']
+  t.extra_args += ["--verbose"] if ENV["VERBOSE_MINITEST"]
 end
 
 task :default => [:compile, :test]


### PR DESCRIPTION
I saw @bnoordhuis's change in https://github.com/rubyjs/mini_racer/pull/352.

I think instead of swallowing the error because it breaks in CI, we should fix the CI setup. I suspect that the TZInfo zoneinfo data is simply missing in the Ruby alpine docker image.

I tested this with docker and `ruby:3.4-alpine`. When I install the required tzdata (via `apk add --no-cache tzdata`) it works as expected:

```
irb(main):001> require "active_support"
=> true
irb(main):002> require "active_support/time"
=> true
irb(main):003> Time.zone = "UTC"
=> "UTC"
```

Without the `tzdata`package, it breaks like described in https://github.com/rubyjs/mini_racer/issues/351.