### PR TITLE
CI: Use ubuntu-24.04 for test-truffleruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - "macos-13"
           - "macos-14" # arm64
           - "macos-15" # arm64
-          - "ubuntu-20.04"
+          - "ubuntu-24.04"
         ruby:
           - "truffleruby+graalvm"
 


### PR DESCRIPTION
GitHub discontinued support for `ubuntu-20.04` in April (see https://github.com/actions/runner-images/issues/11101), that's why the `test-truffleruby` job currently fails.