### PR TITLE
Retain string encoding when raising exception

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.c
+++ b/ext/mini_racer_extension/mini_racer_extension.c
@@ -1005,8 +1005,8 @@ static void handle_exception(VALUE e)
 
     if (NIL_P(e))
         return;
-    StringValue(e);
-    s = RSTRING_PTR(e);
+    e = StringValue(e);
+    s = StringValueCStr(e);
     switch (*s) {
     case NO_ERROR:
         return;
@@ -1028,7 +1028,7 @@ static void handle_exception(VALUE e)
     default:
         rb_raise(internal_error, "bad error class %02x", *s);
     }
-    rb_raise(klass, "%s", s+1);
+    rb_enc_raise(rb_enc_get(e), klass, "%s", s+1);
 }
 
 static VALUE context_alloc(VALUE klass)

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -1172,4 +1172,15 @@ class MiniRacerTest < Minitest::Test
       assert_equal(types, %w[number bigint number bigint])
     end
   end
+
+  def test_exception_message_encoding
+    e = nil
+    begin
+      MiniRacer::Context.new.eval("throw Error('ä')")
+    rescue MiniRacer::RuntimeError => e_
+      e = e_
+    end
+    assert e
+    assert_equal(e.message.encoding.to_s, "UTF-8")
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/rubyjs/mini_racer/issues/369