### PR TITLE
JS code can now catch Ruby exceptions

### DIFF
--- a/ext/mini_racer_extension/serde.c
+++ b/ext/mini_racer_extension/serde.c
@@ -194,17 +194,21 @@ static inline int r_zigzag(const uint8_t **p, const uint8_t *pe, int64_t *r)
     return 0;
 }
 
-static inline void ser_init(Ser *s)
+static void ser_init0(Ser *s)
 {
     memset(s, 0, sizeof(*s));
     buf_init(&s->b);
+}
+
+static inline void ser_init(Ser *s)
+{
+    ser_init0(s);
     w(s, "\xFF\x0F", 2);
 }
 
 static void ser_init1(Ser *s, uint8_t c)
 {
-    memset(s, 0, sizeof(*s));
-    buf_init(&s->b);
+    ser_init0(s);
     w_byte(s, c);
     w(s, "\xFF\x0F", 2);
 }

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -1149,6 +1149,17 @@ class MiniRacerTest < Minitest::Test
     b.kill
   end
 
+  def test_ruby_exception
+    context = MiniRacer::Context.new
+    context.attach("test", proc { raise "boom" })
+    actual = context.eval("try { test() } catch (e) { e }")
+    expected = {
+      "message" => "boom",
+      "stack" => "Error: boom\n    at <eval>:1:7",
+    }
+    assert_equal(actual, expected)
+  end
+
   def test_large_integer
     [10_000_000_001, -2**63, 2**63-1].each { |big_int|
       context = MiniRacer::Context.new


### PR DESCRIPTION
Before this commit exceptions from Ruby callbacks were translated to termination exceptions that cannot be caught by JS code. Turn them into regular exceptions that can be caught.

Fixes: https://github.com/rubyjs/mini_racer/issues/357