### PR TITLE
CI: Adds Ruby 4.0.0-preview2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           - "ruby-3.2"
           - "ruby-3.3"
           - "ruby-3.4"
+          - "ruby-4.0.0-preview2"
 
     name: ${{ matrix.os }} - ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
@@ -96,6 +97,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0.0-preview2"
         runner:
           - "ubuntu-24.04"
           - "ubuntu-24.04-arm"


### PR DESCRIPTION
Initially I wanted to add Ruby head/dev, but that's not that easy for the linux jobs as they use https://hub.docker.com/_/ruby which don't provide nightly builds.

I think it still makes sense to explicitly test Ruby 4 previews (currently 4.0.0-preview2).