### PR TITLE
CI: Add macos-15-intel to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         os:
           - "macos-14" # arm64
           - "macos-15" # arm64
+          - "macos-15-intel"
           - "ubuntu-24.04"
         ruby:
           - "truffleruby+graalvm"
@@ -55,7 +56,8 @@ jobs:
       matrix:
         os:
           - "macos-14" # arm64
-          - "macos-15"
+          - "macos-15" # arm64
+          - "macos-15-intel"
         ruby:
           - "ruby-3.1"
           - "ruby-3.2"


### PR DESCRIPTION
I just saw that `macos-15-intel` images got added back in September (see https://github.com/actions/runner-images/issues/13045).

Maybe this helps figuring out the reason for https://github.com/rubyjs/mini_racer/issues/359, https://github.com/rubyjs/mini_racer/issues/388 and other x86-macOS related issues...