### PR TITLE
Suppress -Wincompatible-pointer-types when needed

### DIFF
--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -32,6 +32,17 @@ $CXXFLAGS += " -fms-extensions"
 
 $CXXFLAGS += " -Wno-reserved-user-defined-literal" if IS_DARWIN
 
+# LLVM Clang 22+ treats -Wincompatible-pointer-types as an error by default;
+# suppress it until the `unsigned long` vs `uint64_t` mismatch in the extension
+# is properly fixed.
+unless try_compile(<<~'C', '-Wincompatible-pointer-types')
+  #include <stdint.h>
+  void f(const uint64_t *p) { (void)p; }
+  void g(void) { unsigned long a[1]; f(a); }
+C
+  $CFLAGS += " -Wno-incompatible-pointer-types"
+end
+
 if IS_DARWIN
   $LDFLAGS.insert(0, " -stdlib=libc++ ")
 else


### PR DESCRIPTION
LLVM Clang 22+ treats -Wincompatible-pointer-types as an error by default, which breaks compilation of mini_racer_extension.c due to the unsigned long vs uint64_t mismatch in the bigint serialization code.

Add -Wno-incompatible-pointer-types to CFLAGS when the compiler rejects an unsigned long to uint64_t pointer conversion, as a workaround until the type mismatch is properly fixed in the extension source.

Ref: https://github.com/rubyjs/mini_racer/issues/359
Ref: https://github.com/rubyjs/mini_racer/pull/361