### PR TITLE
Run single-threaded V8 dispatches on reusable thread

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.c
+++ b/ext/mini_racer_extension/mini_racer_extension.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
+#include <unistd.h>
 #include <math.h>
 
 #if defined(__linux__) && !defined(__GLIBC__)
@@ -136,6 +137,9 @@ typedef struct Context
     VALUE exception;   // pending exception or Qnil
     Buf req, res;      // ruby->v8 request/response, mediated by |mtx| and |cv|
     Buf snapshot;
+    pthread_t single_threaded_thr;
+    pid_t single_threaded_pid;
+    int single_threaded_thr_started;
     // |rr_mtx| stands for "recursive ruby mutex"; it's used to exclude
     // other ruby threads but allow reentrancy from the same ruby thread
     // (think ruby->js->ruby->js calls)
@@ -868,18 +872,10 @@ void v8_dispatch(Context *c)
 // only called when inside v8_call, v8_eval, or v8_pump_message_loop
 void v8_roundtrip(Context *c, const uint8_t **p, size_t *n)
 {
-    struct rendezvous_nogvl *args;
-
     buf_reset(&c->req);
-    if (single_threaded) {
-        assert(*c->res.buf == 'c'); // js -> ruby callback
-        args = &(struct rendezvous_nogvl){c, &c->req, &c->res};
-        rb_thread_call_with_gvl(rendezvous_callback, args);
-    } else {
-        pthread_cond_signal(&c->cv);
-        while (!c->req.len)
-            pthread_cond_wait(&c->cv, &c->mtx);
-    }
+    pthread_cond_signal(&c->cv);
+    while (!c->req.len)
+        pthread_cond_wait(&c->cv, &c->mtx);
     buf_reset(&c->res);
     *p = c->req.buf;
     *n = c->req.len;
@@ -991,10 +987,45 @@ fail:
     goto out;
 }
 
+static void *single_threaded_runner(void *arg)
+{
+    Context *c;
+
+    c = arg;
+    pthread_mutex_lock(&c->mtx);
+    for (;;) {
+        while (!c->req.len && c->quit < 2)
+            pthread_cond_wait(&c->cv, &c->mtx);
+        if (c->quit >= 2)
+            break;
+        v8_single_threaded_enter(c->pst, c, dispatch);
+        pthread_cond_signal(&c->cv);
+    }
+    pthread_mutex_unlock(&c->mtx);
+    return NULL;
+}
+
+static int single_threaded_runner_start(Context *c)
+{
+    pid_t pid;
+    int r;
+
+    pid = getpid();
+    if (c->single_threaded_thr_started && c->single_threaded_pid == pid)
+        return 0;
+    c->single_threaded_thr_started = 0;
+    c->single_threaded_pid = pid;
+    r = pthread_create(&c->single_threaded_thr, NULL, single_threaded_runner, c);
+    if (!r)
+        c->single_threaded_thr_started = 1;
+    return r;
+}
+
 static inline void *rendezvous_nogvl(void *arg)
 {
     struct rendezvous_nogvl *a;
     Context *c;
+    int r;
 
     a = arg;
     c = a->context;
@@ -1010,7 +1041,16 @@ next:
     assert(c->res.len == 0);
     buf_move(a->req, &c->req); // v8 thread takes ownership of req
     if (single_threaded) {
-        v8_single_threaded_enter(c->pst, c, dispatch);
+        r = single_threaded_runner_start(c);
+        if (r) {
+            buf_move(&c->req, a->req);
+            pthread_mutex_unlock(&c->mtx);
+            c->depth--;
+            pthread_mutex_unlock(&c->rr_mtx);
+            return (void *)(intptr_t)r;
+        }
+        pthread_cond_signal(&c->cv);
+        do pthread_cond_wait(&c->cv, &c->mtx); while (!c->res.len);
     } else {
         pthread_cond_signal(&c->cv);
         do pthread_cond_wait(&c->cv, &c->mtx); while (!c->res.len);
@@ -1019,6 +1059,7 @@ next:
     pthread_mutex_unlock(&c->mtx);
     if (*a->res->buf == 'c') { // js -> ruby callback?
         rb_thread_call_with_gvl(rendezvous_callback, a);
+        buf_reset(a->res);
         goto next;
     }
     c->depth--;
@@ -1028,12 +1069,16 @@ next:
 
 static void rendezvous_no_des(Context *c, Buf *req, Buf *res)
 {
+    void *r;
+
     if (atomic_load(&c->quit)) {
         buf_reset(req);
         rb_raise(context_disposed_error, "disposed context");
     }
-    rb_nogvl(rendezvous_nogvl, &(struct rendezvous_nogvl){c, req, res},
-             NULL, NULL, 0);
+    r = rb_nogvl(rendezvous_nogvl, &(struct rendezvous_nogvl){c, req, res},
+                 NULL, NULL, 0);
+    if (r)
+        rb_raise(runtime_error, "pthread_create: %s", strerror((int)(intptr_t)r));
 }
 
 // send request to & receive reply from v8 thread; takes ownership of |req|
@@ -1190,6 +1235,13 @@ static void *context_free_thread_do(void *arg)
     Context *c;
 
     c = arg;
+    if (single_threaded && c->single_threaded_thr_started && c->single_threaded_pid == getpid()) {
+        pthread_mutex_lock(&c->mtx);
+        c->quit = 2;
+        pthread_cond_signal(&c->cv);
+        pthread_mutex_unlock(&c->mtx);
+        pthread_join(c->single_threaded_thr, NULL);
+    }
     v8_single_threaded_dispose(c->pst);
     context_destroy(c);
     return NULL;


### PR DESCRIPTION
## Summary

Fixes `:single_threaded` so V8 still uses the single-threaded platform, but MiniRacer no longer runs V8 dispatches directly on the Ruby caller thread.

Instead, each context lazily starts a reusable single-threaded V8 runner thread. The important bit: the runner waits outside V8, and only enters V8 for an individual dispatch:

```text
Ruby caller thread
  rb_nogvl
    ensure reusable runner thread exists for this pid
    signal request
    wait for response / callback

runner thread
  wait outside V8
  on request:
    enter V8 with Locker/IsolateScope/HandleScope
    dispatch request
    exit V8 completely
  wait outside V8 again
```

JS→Ruby callbacks rendezvous back to the original Ruby caller thread through the existing condition-variable protocol, so the V8 runner thread does not directly reacquire the GVL or run Ruby code.

This addresses rubyjs/mini_racer#415. In that workload, the previous same-Ruby-thread `:single_threaded` path could crash during V8 exception unwinding in `v8::internal::wasm::StackMemory::jslimit()`. The crash appears to depend on the embedding shape where V8 runs on a Ruby thread and callbacks re-enter Ruby/GVL from inside the V8 stack.

No extra public option is added. `MiniRacer::Platform.set_flags!(:single_threaded)` keeps the existing public API.

## Fork behavior

This preserves the important historical property of `:single_threaded`: an inherited context can still be used after `fork`.

The reusable runner is tracked per process id. If a context is inherited into a child process, the parent runner thread is gone, so the next dispatch notices the pid change and starts a new runner thread in the child.

The runner does not hold V8's `Locker` or `Isolate::Scope` while idle, so the normal idle-at-fork case does not inherit a V8 thread parked inside the isolate.

## Changes

- Replace direct same-Ruby-thread `v8_single_threaded_enter(...)` dispatches with a reusable per-context runner thread.
- The runner enters/exits V8 around each dispatch instead of holding V8 state while idle.
- Make `v8_roundtrip()` use the condition-variable rendezvous path for `:single_threaded` too.
- Keep Ruby callbacks running on the original Ruby caller thread, not on the V8 runner thread.
- Track the runner pid and recreate the runner after fork.
- Keep the existing single-threaded persistent V8 handles, so contexts remain alive between calls and across ordinary fork boundaries.

## Validation

MiniRacer test suite:

```text
103 runs, 188 assertions, 0 failures, 0 errors, 3 skips
```

Forking smoke test:

```sh
bundle exec ruby test/test_forking.rb
# exit 0
```

Fork stress:

```sh
for i in $(seq 1 10); do bundle exec ruby test/test_forking.rb || exit 1; done
# fork-stress-ok
```

Single-threaded Ruby callback smoke:

```sh
bundle exec ruby -Ilib -e 'require "mini_racer"; MiniRacer::Platform.set_flags! :single_threaded; c=MiniRacer::Context.new; c.attach("rb", proc { |x| x + 1 }); raise unless c.eval("rb(41)") == 42; puts "callback ok"'
# callback ok
```

Standalone rubyjs/mini_racer#415 replay now completes with the normal existing flag:

```ruby
MiniRacer::Platform.set_flags!(:single_threaded)
```

```text
visited, current_url=http://www.example.com/about status=200
checking .about__stats-item.site-creation-date span text="Created 2 months ago" iterations=1
iteration 0: found element text="Created 2 months ago"; asking has_text?/visible?
done without crash
```

The original Discourse repro from #415 also passes unchanged:

```text
1 example, 0 failures
```
