### PR TITLE
PERF: release the GVL while the V8 thread boots the isolate

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.c
+++ b/ext/mini_racer_extension/mini_racer_extension.c
@@ -1603,6 +1603,21 @@ out:
         rb_thread_lock_native_thread();
 }
 
+// Blocks until the V8 thread finishes booting the isolate, which includes
+// snapshot deserialization (v8::Isolate::New) and safe-context setup. None of
+// that touches Ruby objects -- the snapshot is a plain C buffer already copied
+// into |c->snapshot| -- so we release the GVL while waiting, letting other Ruby
+// threads (e.g. a background pool refilling more contexts) truly run meanwhile.
+static void *context_boot_wait(void *arg)
+{
+    Context *c;
+
+    c = arg;
+    barrier_wait(&c->early_init);
+    barrier_wait(&c->late_init);
+    return NULL;
+}
+
 static VALUE context_initialize(int argc, VALUE *argv, VALUE self)
 {
     VALUE kwargs, a, k, v;
@@ -1670,8 +1685,7 @@ init:
         pthread_attr_destroy(&attr);
         if (r)
             goto fail;
-        barrier_wait(&c->early_init);
-        barrier_wait(&c->late_init);
+        rb_thread_call_without_gvl(context_boot_wait, c, NULL, NULL);
     }
     return Qnil;
 fail:


### PR DESCRIPTION
## Summary

In the default multithreaded mode, `Context.new` spawns the V8 thread and then blocks on the `late_init` barrier while that thread runs `v8::Isolate::New` (snapshot deserialization) and the safe-context setup. `barrier_wait` is a plain `pthread_cond_wait`, so the **booting Ruby thread holds the GVL for the entire boot**, freezing every other Ruby thread for the full duration.

The V8 thread touches no Ruby objects during boot — the snapshot is a plain C buffer already copied into `c->snapshot` — so this change releases the GVL around the barrier waits via `rb_thread_call_without_gvl` (the same idiom already used by `Context#dispose`). A background thread booting contexts from a snapshot (e.g. a warm-context pool) now genuinely overlaps with the main thread instead of stalling it.

## Why it's safe

- The boot path (`early_init` → `v8::Isolate::New` / context / safe-context setup → `late_init`) makes **no Ruby calls and allocates no VALUEs** before `late_init`, so the initializing thread never needed to hold the GVL there.
- `self`/`c` stay alive across the GVL-released wait via MRI's conservative machine-stack marking — identical to the existing `rb_thread_call_without_gvl(context_dispose_do, c, NULL, NULL)` in `Context#dispose`.
- `context_mark` only reads `c->procs` / `c->exception`, both initialized before the V8 thread exists and untouched during boot, so a concurrent GC mark is race-free.
- Only the multithreaded branch is affected; `:single_threaded` mode (which runs the boot inline on the Ruby thread) is unchanged.

## Measurement

Synthetic microbenchmark (background thread booting contexts from a heavy snapshot while the main thread runs a tight Ruby loop): on `main`, every background boot stalls the main thread for the full ~8 ms deserialization; with this change those per-boot stalls disappear.

Real-world A/B in a downstream app that maintains a warm `Context` pool with background async refill (real snapshot + pool + refill, median of 8 runs, identical workload): **~1.52s → ~1.40s wall, ≈ 8.5% faster**.

All existing tests pass (`rake test`, 113 runs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)