### PR TITLE
Bump Ruby version to >=3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,6 @@ jobs:
           - "macos-26" # arm64
           - "macos-26-intel"
         ruby:
-          - "ruby-3.1"
-          - "ruby-3.2"
           - "ruby-3.3"
           - "ruby-3.4"
           - "ruby-4.0"
@@ -91,8 +89,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "3.1"
-          - "3.2"
           - "3.3"
           - "3.4"
           - "4.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=3.2
+ARG RUBY_VERSION=4
 FROM ruby:${RUBY_VERSION}
 
 RUN test ! -f /etc/alpine-release || apk add --no-cache build-base git

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |spec|
     ext/mini_racer_extension/extconf.rb
   ]
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.3"
 end


### PR DESCRIPTION
As per our policy, mini_racer only supports non-EOL'd versions of Ruby. Currently Ruby 3.3+ is supported, see https://www.ruby-lang.org/en/downloads/branches/.