### PR TITLE
FIX: skip perform_microtask_checkpoint tests on TruffleRuby (they hang CI)

### DIFF
--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -987,11 +987,17 @@ class MiniRacerTest < Minitest::Test
   end
 
   def test_perform_microtask_checkpoint_returns_nil
+    if RUBY_ENGINE == "truffleruby"
+      skip "TruffleRuby does not implement perform_microtask_checkpoint (V8-only)"
+    end
     context = MiniRacer::Context.new
     assert_nil(context.perform_microtask_checkpoint)
   end
 
   def test_perform_microtask_checkpoint_drains_from_callback
+    if RUBY_ENGINE == "truffleruby"
+      skip "TruffleRuby does not implement perform_microtask_checkpoint (V8-only)"
+    end
     context = MiniRacer::Context.new
     seen    = []
 


### PR DESCRIPTION
## Problem

The `truffleruby+graalvm` CI jobs (ubuntu + macOS) have been red: the job exceeds its `timeout-minutes: 10` with no test output (the graal.js stdout is buffered, so the CI log just shows `# Running:` and then nothing until the runner is killed).

## Root cause

`Context#perform_microtask_checkpoint` is a **V8-only** API — the TruffleRuby backend (`lib/mini_racer/truffleruby.rb`) does not implement it. The two tests added with that feature call it **without a TruffleRuby guard**:

- `test_perform_microtask_checkpoint_returns_nil`
- `test_perform_microtask_checkpoint_drains_from_callback`

The second invokes `perform_microtask_checkpoint` from inside a JS→Ruby callback (`drain()`), which **hangs the TruffleRuby graal.js context indefinitely**. That single hang trips the 10-minute job timeout and takes the whole suite red.

## Fix

Skip both tests on TruffleRuby, matching the convention already used by other V8-only tests in this file (`max_memory`, `webassembly`, …).

## Verification

Reproduced locally with `truffleruby+graalvm-34.0.1`:

- **Before:** `bundle exec rake test` hangs at `test_perform_microtask_checkpoint_drains_from_callback` (never completes).
- **After:** the suite completes — `113 runs, 0 failures, 0 errors, 34 skips`.

## Note (out of scope)

A separate failure exists on the `linux-ubuntu-24.04-arm - ruby-3.3 - musl` job: `test_forking` intermittently fails (the `test/test_forking.rb` child, exercising `single_threaded` + `fork` + GC, crashes). It is **flaky** — it passed in some runs and failed in others on identical code, and could not be reproduced in 20+ runs under a faithful `aarch64-linux-musl` container. This PR does not address it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
