### PR TITLE
Feature: Faster handling of int arrays

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -41,7 +41,7 @@ bundle exec ruby benchmark/run.rb \
   --git-tags v0.21.0,v0.21.3,working \
   --tags transpile,single-threaded \
   --transpile-iterations 1 \
-  --rounds 3
+  --rounds 7
 
 # Only single-threaded jobs
 bundle exec ruby benchmark/run.rb --tags single-threaded
@@ -52,7 +52,7 @@ bundle exec ruby benchmark/run.rb --tags serde,single-threaded
 # Only real-world transpile on the default platform
 bundle exec ruby benchmark/run.rb --tags transpile,default
 
-# Quick smoke run
+# Quick smoke run (reduced serde scale, one transpile iteration, one round, one warmup)
 bundle exec ruby benchmark/run.rb --tags all --quick
 
 # Save machine-readable results
@@ -70,7 +70,7 @@ Useful shared options:
 --git-tags REFS             Comma-separated git tags/refs to run; use `working` for this checkout
 --worktree-root PATH        Temporary worktree root for --git-tags
 --no-setup-git-refs         Skip bundle install + rake compile for git refs
---rounds N                  Timed samples per case
+--rounds N                  Timed samples per case; transpile multi-round runs floor this to 7
 --warmup N                  Warmup iterations per case
 --only REGEX                Run matching case names inside selected suites
 --serde-scale SCALE         Scale serde iteration counts

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -68,6 +68,7 @@ if options[:quick]
   options[:serde_scale] ||= 0.1
   options[:transpile_iterations] ||= 1
   options[:rounds] ||= 1
+  options[:warmup] ||= 1
 end
 
 unknown_tags = options[:tags] - ALL_TAGS

--- a/benchmark/transpile/README.md
+++ b/benchmark/transpile/README.md
@@ -35,8 +35,9 @@ bundle exec ruby benchmark/transpile/bench.rb --list-resources
 # Download and checksum resources without running the benchmark
 bundle exec ruby benchmark/transpile/bench.rb --fetch-only
 
-# Quick one-iteration run
-BENCH_ITERATIONS=1 bundle exec ruby benchmark/transpile/bench.rb
+# Quick one-iteration smoke run; use rounds=1 to opt out of the stable-sample
+# floor used for multi-round transpile runs.
+BENCH_ITERATIONS=1 BENCH_ROUNDS=1 BENCH_WARMUP=1 bundle exec ruby benchmark/transpile/bench.rb
 
 # Run on MiniRacer's single-threaded platform
 BENCH_SINGLE_THREADED=1 bundle exec ruby benchmark/transpile/bench.rb
@@ -52,6 +53,12 @@ bundle exec ruby benchmark/transpile/bench.rb --only 'transpile_call_source_to_e
 # Machine-readable output
 bundle exec ruby benchmark/transpile/bench.rb --json --output /tmp/mini_racer-transpile.json
 ```
+
+Before timing each benchmark case, the suite performs untimed warmup iterations.
+Multi-round runs collect at least seven timed samples because Babel/pdf.js
+transpilation has regular V8 GC outliers; with only two or three samples, the
+median can report an arbitrary GC phase instead of a stable center. Use
+`--rounds 1` only for smoke runs.
 
 Benchmark cases:
 

--- a/benchmark/transpile/bench.rb
+++ b/benchmark/transpile/bench.rb
@@ -17,6 +17,8 @@ RESOURCES = JSON.parse(File.read(RESOURCE_FILE))
 DEFAULT_BABEL = "babel_standalone_7_26_10"
 DEFAULT_SOURCE = "pdfjs_worker_4_10_38"
 
+DEFAULT_STABLE_ROUNDS = 7
+
 CaseResult = Struct.new(:name, :iterations, :samples, keyword_init: true) do
   def median_seconds
     samples.sort[samples.length / 2]
@@ -39,8 +41,8 @@ options = {
   cache_dir: File.join(ROOT, "tmp", "benchmark", "transpile"),
   source: DEFAULT_SOURCE,
   iterations: Integer(ENV.fetch("BENCH_ITERATIONS", "3")),
-  rounds: Integer(ENV.fetch("BENCH_ROUNDS", "1")),
-  warmup: Integer(ENV.fetch("BENCH_WARMUP", "1")),
+  rounds: Integer(ENV.fetch("BENCH_ROUNDS", DEFAULT_STABLE_ROUNDS.to_s)),
+  warmup: Integer(ENV.fetch("BENCH_WARMUP", "5")),
   timeout: Integer(ENV.fetch("BENCH_TIMEOUT", "300000")),
   only: nil,
   json: false,
@@ -61,11 +63,11 @@ OptionParser.new do |parser|
     options[:iterations] = value
   end
 
-  parser.on("--rounds COUNT", Integer, "Timed samples per case; default: BENCH_ROUNDS or 1") do |value|
+  parser.on("--rounds COUNT", Integer, "Timed samples per case; default: BENCH_ROUNDS or #{DEFAULT_STABLE_ROUNDS}") do |value|
     options[:rounds] = value
   end
 
-  parser.on("--warmup COUNT", Integer, "Warmup iterations before each timed sample; default: BENCH_WARMUP or 1") do |value|
+  parser.on("--warmup COUNT", Integer, "Untimed warmup iterations before timed samples; default: BENCH_WARMUP or 5") do |value|
     options[:warmup] = value
   end
 
@@ -162,6 +164,12 @@ babel_path = fetch_resource(options[:cache_dir], DEFAULT_BABEL)
 source_path = fetch_resource(options[:cache_dir], options[:source])
 exit if options[:fetch_only]
 
+requested_rounds = options[:rounds]
+if options[:rounds] > 1 && options[:rounds] < DEFAULT_STABLE_ROUNDS
+  warn "raising transpile --rounds from #{options[:rounds]} to #{DEFAULT_STABLE_ROUNDS} for stable medians; use --rounds 1 for smoke runs"
+  options[:rounds] = DEFAULT_STABLE_ROUNDS
+end
+
 babel_source = File.binread(babel_path)
 transpile_source = File.binread(source_path)
 source_resource = RESOURCES.fetch(options[:source])
@@ -208,48 +216,69 @@ def new_context(timeout, babel_source, source = nil)
   ctx
 end
 
-ctx = new_context(options[:timeout], babel_source, transpile_source)
+BenchmarkCase = Struct.new(:name, :iterations, :block, keyword_init: true)
 
-cases = {
-  "babel/load_standalone" => proc do
-    MiniRacer::Context.new(timeout: options[:timeout]).eval(babel_source)
-  end,
-  "babel/transpile_cached_source_to_es6_length" => proc do
-    ctx.call("__miniRacerTransformCachedLength")
-  end,
-  "babel/transpile_call_source_to_es6_length" => proc do
-    ctx.call("__miniRacerTransformLength", transpile_source)
-  end,
-  "babel/transpile_call_source_to_es6_code" => proc do
-    ctx.call("__miniRacerTransformCode", transpile_source).bytesize
-  end
-}
-
-selected = if options[:only]
-  cases.select { |name, _| name.match?(options[:only]) }
-else
-  cases
-end
-abort "No benchmarks matched" if selected.empty?
-
-results = []
-selected.each do |name, block|
+def measure_case(bench, warmup:, rounds:)
   samples = []
 
-  options[:rounds].times do
+  warmup.times do
+    GC.start
+    bench.block.call
+  end
+
+  rounds.times do
     begin
       GC.start
       GC.disable
-      options[:warmup].times { block.call }
       started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      options[:iterations].times { block.call }
+      bench.iterations.times { bench.block.call }
       samples << (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at)
     ensure
       GC.enable
     end
   end
 
-  result = CaseResult.new(name: name, iterations: options[:iterations], samples: samples).to_h
+  samples
+end
+
+ctx = new_context(options[:timeout], babel_source, transpile_source)
+
+cases = [
+  BenchmarkCase.new(
+    name: "babel/load_standalone",
+    iterations: options[:iterations],
+    block: lambda do
+      MiniRacer::Context.new(timeout: options[:timeout]).eval(babel_source)
+    end
+  ),
+  BenchmarkCase.new(
+    name: "babel/transpile_cached_source_to_es6_length",
+    iterations: options[:iterations],
+    block: -> { ctx.call("__miniRacerTransformCachedLength") }
+  ),
+  BenchmarkCase.new(
+    name: "babel/transpile_call_source_to_es6_length",
+    iterations: options[:iterations],
+    block: -> { ctx.call("__miniRacerTransformLength", transpile_source) }
+  ),
+  BenchmarkCase.new(
+    name: "babel/transpile_call_source_to_es6_code",
+    iterations: options[:iterations],
+    block: -> { ctx.call("__miniRacerTransformCode", transpile_source).bytesize }
+  )
+]
+
+selected = if options[:only]
+  cases.select { |bench| bench.name.match?(options[:only]) }
+else
+  cases
+end
+abort "No benchmarks matched" if selected.empty?
+
+results = []
+selected.each do |bench|
+  samples = measure_case(bench, warmup: options[:warmup], rounds: options[:rounds])
+  result = CaseResult.new(name: bench.name, iterations: bench.iterations, samples: samples).to_h
   results << result
   unless options[:json]
     puts "%-48s n=%-4d total=%10.3fms per=%10.3fms" % [
@@ -275,6 +304,7 @@ payload = {
     target: "Babel preset-env to Chrome 51 / ES2015-ish, modules preserved",
     single_threaded: options[:single_threaded],
     iterations: options[:iterations],
+    requested_rounds: requested_rounds,
     rounds: options[:rounds],
     warmup: options[:warmup]
   },

--- a/ext/mini_racer_extension/mini_racer_extension.c
+++ b/ext/mini_racer_extension/mini_racer_extension.c
@@ -200,6 +200,7 @@ static VALUE snapshot_error;
 static VALUE terminated_error;
 static VALUE context_class;
 static VALUE snapshot_class;
+static ID call_method_id;
 static VALUE date_time_class;
 static VALUE binary_class;
 static VALUE js_function_class;
@@ -241,6 +242,41 @@ struct rendezvous_des
     DesCtx *d;
     Buf *res;
 };
+
+// Fast callback protocol for the common JS -> Ruby -> JS integer case.
+// 'f' request: marker, argc, callback id, argc int32 arguments.
+// 'i' reply: marker, int32 return value. Anything outside that narrow shape
+// falls back to the regular V8 serializer/deserializer protocol.
+#define FAST_CALLBACK_MAX_ARGS 32
+#define FAST_CALLBACK_REQUEST_SIZE(argc) (2 + sizeof(int32_t) * (1 + (argc)))
+#define FAST_CALLBACK_REPLY_SIZE (1 + sizeof(int32_t))
+
+static int fast_read_i32(const uint8_t **p, const uint8_t *pe, int32_t *out)
+{
+    if ((size_t)(pe - *p) < sizeof(*out))
+        return -1;
+    memcpy(out, *p, sizeof(*out));
+    *p += sizeof(*out);
+    return 0;
+}
+
+static int fast_fixnum_to_i32(VALUE value, int32_t *out)
+{
+    long v;
+
+    if (TYPE(value) != T_FIXNUM)
+        return 0;
+    v = FIX2LONG(value);
+    if (v < INT32_MIN || v > INT32_MAX)
+        return 0;
+    *out = (int32_t)v;
+    return 1;
+}
+
+static int fast_callback_marker(uint8_t marker)
+{
+    return marker == 'c' || marker == 'f';
+}
 
 static void DesCtx_init(DesCtx *c)
 {
@@ -966,27 +1002,77 @@ static VALUE deserialize(VALUE arg)
 static VALUE rendezvous_callback_do(VALUE arg)
 {
     struct rendezvous_nogvl *a;
-    VALUE func, args;
+    VALUE func;
+    VALUE argv[FAST_CALLBACK_MAX_ARGS];
     Context *c;
-    DesCtx d;
     Buf *b;
+    const uint8_t *p, *pe;
+    int32_t id32, v32;
     long id;
+    uint8_t argc;
 
     a = (void *)arg;
     b = a->res;
     c = a->context;
     assert(b->len > 0);
-    assert(*b->buf == 'c');
-    DesCtx_init(&d);
-    args = deserialize1(&d, b->buf+1, b->len-1); // skip 'c' marker
-    func = rb_ary_pop(args); // callback id
-    if (!RB_INTEGER_TYPE_P(func))
-        rb_raise(runtime_error, "bad callback id");
-    id = NUM2LONG(func);
-    if (id < 0 || id >= RARRAY_LEN(c->procs))
-        rb_raise(runtime_error, "bad callback id");
-    func = rb_ary_entry(c->procs, id);
-    return rb_funcall2(func, rb_intern("call"), RARRAY_LENINT(args), RARRAY_PTR(args));
+    assert(fast_callback_marker(*b->buf));
+
+    if (*b->buf == 'f') {
+        if (b->len < 2)
+            rb_raise(runtime_error, "bad fast callback request");
+        argc = b->buf[1];
+        if (argc > FAST_CALLBACK_MAX_ARGS || b->len != FAST_CALLBACK_REQUEST_SIZE(argc))
+            rb_raise(runtime_error, "bad fast callback request");
+        p = b->buf + 2;
+        pe = b->buf + b->len;
+        if (fast_read_i32(&p, pe, &id32))
+            rb_raise(runtime_error, "bad fast callback id");
+        id = id32;
+        if (id < 0 || id >= RARRAY_LEN(c->procs))
+            rb_raise(runtime_error, "bad callback id");
+        for (uint8_t i = 0; i < argc; i++) {
+            if (fast_read_i32(&p, pe, &v32))
+                rb_raise(runtime_error, "bad fast callback argument");
+            argv[i] = INT2NUM(v32);
+        }
+        func = rb_ary_entry(c->procs, id);
+        return rb_funcall2(func, call_method_id, argc, argv);
+    }
+
+    {
+        VALUE args;
+        DesCtx d;
+
+        DesCtx_init(&d);
+        args = deserialize1(&d, b->buf+1, b->len-1); // skip 'c' marker
+        func = rb_ary_pop(args); // callback id
+        if (!RB_INTEGER_TYPE_P(func))
+            rb_raise(runtime_error, "bad callback id");
+        id = NUM2LONG(func);
+        if (id < 0 || id >= RARRAY_LEN(c->procs))
+            rb_raise(runtime_error, "bad callback id");
+        func = rb_ary_entry(c->procs, id);
+        return rb_funcall2(func, call_method_id, RARRAY_LENINT(args), RARRAY_PTR(args));
+    }
+}
+
+static int fast_callback_reply(struct rendezvous_nogvl *a, VALUE result)
+{
+    int32_t value;
+    uint8_t reply[FAST_CALLBACK_REPLY_SIZE];
+    Buf b;
+
+    if (*a->res->buf != 'f')
+        return 0;
+    if (!fast_fixnum_to_i32(result, &value))
+        return 0;
+
+    reply[0] = 'i';
+    memcpy(reply + 1, &value, sizeof(value));
+    buf_init(&b);
+    buf_put(&b, reply, sizeof(reply));
+    buf_move(&b, a->req);
+    return 1;
 }
 
 // called with |rr_mtx| and GVL held; |mtx| is unlocked
@@ -1008,6 +1094,8 @@ static void *rendezvous_callback(void *arg)
         rb_set_errinfo(Qnil);
         goto fail;
     }
+    if (fast_callback_reply(a, r))
+        return NULL;
     ser_init1(&s, 'c'); // callback reply
     if (serialize(&s, r)) { // should not happen
         c->exception = rb_exc_new_cstr(internal_error, s.err);
@@ -1167,7 +1255,7 @@ next:
     pthread_cond_broadcast(&c->cv);
     pthread_mutex_unlock(&c->mtx);
     atomic_store(&a->active, 0);
-    if (*a->res->buf == 'c') { // js -> ruby callback?
+    if (a->res->len && fast_callback_marker(*a->res->buf)) { // js -> ruby callback?
         rb_thread_call_with_gvl(rendezvous_callback, a);
         buf_reset(a->res);
         if (atomic_load(&c->quit)) {
@@ -1226,7 +1314,7 @@ static void *rendezvous_cancel_nogvl(void *arg)
             pthread_cond_wait(&c->cv, &c->mtx);
         if (!c->res_ready)
             break;
-        if (c->res.len && *c->res.buf != 'c')
+        if (c->res.len && !fast_callback_marker(*c->res.buf))
             break;
         buf_reset(&c->res);
         c->res_ready = 0;
@@ -2140,6 +2228,8 @@ void Init_mini_racer_extension(void)
     terminated_error = rb_define_class_under(m, "ScriptTerminatedError", c);
 
     rb_define_method(script_error, "cause", script_error_cause, 0);
+
+    call_method_id = rb_intern("call");
 
     c = context_class = rb_define_class_under(m, "Context", rb_cObject);
     rb_define_method(c, "initialize", context_initialize, -1);

--- a/ext/mini_racer_extension/mini_racer_v8.cc
+++ b/ext/mini_racer_extension/mini_racer_v8.cc
@@ -124,6 +124,55 @@ struct Serialized
     }
 };
 
+// Mirrors the fast callback protocol in mini_racer_extension.c. It only handles
+// primitive int32 arguments and fixnum int32 return values; all other cases keep
+// using V8's serializer, preserving the existing safety/filtering semantics.
+constexpr int kFastCallbackMaxArgs = 32;
+constexpr size_t kFastCallbackReplySize = 1 + sizeof(int32_t);
+
+bool read_fast_i32(const uint8_t **p, const uint8_t *pe, int32_t *out)
+{
+    if (static_cast<size_t>(pe - *p) < sizeof(*out)) return false;
+    memcpy(out, *p, sizeof(*out));
+    *p += sizeof(*out);
+    return true;
+}
+
+bool fast_callback_request(State& st, Callback *cb, const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    int argc = info.Length();
+    if (argc > kFastCallbackMaxArgs) return false;
+
+    uint8_t buf[2 + sizeof(int32_t) * (1 + kFastCallbackMaxArgs)];
+    uint8_t *p = buf;
+    *p++ = 'f';
+    *p++ = static_cast<uint8_t>(argc);
+    memcpy(p, &cb->id, sizeof(cb->id));
+    p += sizeof(cb->id);
+
+    for (int i = 0; i < argc; i++) {
+        if (!info[i]->IsInt32()) return false;
+        int32_t value = info[i].As<v8::Int32>()->Value();
+        memcpy(p, &value, sizeof(value));
+        p += sizeof(value);
+    }
+
+    v8_reply(st.ruby_context, buf, p - buf);
+    return true;
+}
+
+bool read_fast_callback_reply(v8::Isolate *isolate, const uint8_t *p, size_t n,
+                              v8::ReturnValue<v8::Value> out)
+{
+    if (n != kFastCallbackReplySize) return false;
+    int32_t value;
+    const uint8_t *cursor = p + 1;
+    const uint8_t *pe = p + n;
+    if (!read_fast_i32(&cursor, pe, &value)) return false;
+    out.Set(v8::Int32::New(isolate, value));
+    return true;
+}
+
 void append_bytes(std::vector<char>& out, const char *p, size_t n)
 {
     out.insert(out.end(), p, p + n);
@@ -486,22 +535,24 @@ void v8_api_callback(const v8::FunctionCallbackInfo<v8::Value>& info)
     auto ext = v8::External::Cast(*info.Data());
     Callback *cb = static_cast<Callback*>(ext->Value());
     State& st = *cb->st;
-    v8::Local<v8::Array> request;
-    {
-        v8::Context::Scope context_scope(st.safe_context);
-        request = v8::Array::New(st.isolate, 1 + info.Length());
-    }
-    for (int i = 0, n = info.Length(); i < n; i++) {
-        request->Set(st.context, i, sanitize(st, info[i])).Check();
-    }
-    auto id = v8::Int32::New(st.isolate, cb->id);
-    request->Set(st.context, info.Length(), id).Check(); // callback id
-    {
-        Serialized serialized(st, request);
-        if (!serialized.data) return; // exception pending
-        uint8_t marker = 'c'; // callback marker
-        v8_reply(st.ruby_context, &marker, 1);
-        v8_reply(st.ruby_context, serialized.data, serialized.size);
+    if (!fast_callback_request(st, cb, info)) {
+        v8::Local<v8::Array> request;
+        {
+            v8::Context::Scope context_scope(st.safe_context);
+            request = v8::Array::New(st.isolate, 1 + info.Length());
+        }
+        for (int i = 0, n = info.Length(); i < n; i++) {
+            request->Set(st.context, i, sanitize(st, info[i])).Check();
+        }
+        auto id = v8::Int32::New(st.isolate, cb->id);
+        request->Set(st.context, info.Length(), id).Check(); // callback id
+        {
+            Serialized serialized(st, request);
+            if (!serialized.data) return; // exception pending
+            uint8_t marker = 'c'; // callback marker
+            v8_reply(st.ruby_context, &marker, 1);
+            v8_reply(st.ruby_context, serialized.data, serialized.size);
+        }
     }
     const uint8_t *p;
     size_t n;
@@ -509,6 +560,15 @@ void v8_api_callback(const v8::FunctionCallbackInfo<v8::Value>& info)
         v8_roundtrip(st.ruby_context, &p, &n);
         if (*p == 'c') // callback reply
             break;
+        if (*p == 'i') { // fast int32 callback reply
+            if (read_fast_callback_reply(st.isolate, p, n, info.GetReturnValue()))
+                return;
+            auto message = v8::String::NewFromUtf8Literal(st.isolate, "bad fast callback reply");
+            auto exception = v8::Exception::Error(message);
+            st.ruby_exception.Reset(st.isolate, exception);
+            st.isolate->ThrowException(exception);
+            return;
+        }
         if (*p == 'e') { // ruby exception pending
             v8::Local<v8::String> message;
             auto type = v8::NewStringType::kNormal;

--- a/test/single_threaded_test.rb
+++ b/test/single_threaded_test.rb
@@ -49,6 +49,63 @@ class MiniRacerSingleThreadedTest < Minitest::Test
     RUBY
   end
 
+  def test_int_callback_falls_back_for_non_int_return
+    assert_single_threaded_script <<~'RUBY'
+      context = MiniRacer::Context.new
+      context.attach("wide", proc { |value| value + 2**40 })
+      context.attach("stringify", proc { |value| "v#{value}" })
+      context.attach("arrayify", proc { |value| [value, value + 1] })
+
+      raise "bad wide result" unless context.eval("wide(7)") == 2**40 + 7
+      raise "bad string result" unless context.eval("stringify(7)") == "v7"
+      raise "bad array result" unless context.eval("arrayify(7)") == [7, 8]
+    RUBY
+  end
+
+  def test_int_callback_exception_propagates
+    assert_single_threaded_script <<~'RUBY'
+      context = MiniRacer::Context.new
+      context.attach("boom", proc { |value| raise "boom #{value}" })
+
+      begin
+        context.eval("boom(7)")
+        raise "expected callback exception"
+      rescue RuntimeError => e
+        raise "wrong exception: #{e.class}: #{e.message}" unless e.message.include?("boom 7")
+      end
+    RUBY
+  end
+
+  def test_int_callback_can_make_nested_js_call
+    assert_single_threaded_script <<~'RUBY'
+      context = MiniRacer::Context.new
+      context.eval("function js_add(a, b) { return a + b }")
+      context.attach("ruby_calls_js", proc { |value| context.call("js_add", value, 1) })
+
+      raise "bad nested callback result" unless context.eval("ruby_calls_js(41)") == 42
+    RUBY
+  end
+
+  def test_callback_with_many_int_args_uses_general_path
+    assert_single_threaded_script <<~'RUBY'
+      context = MiniRacer::Context.new
+      context.attach("count_args", proc { |*args| args.length })
+      args = Array.new(33) { |i| i }.join(",")
+
+      raise "bad many-args callback result" unless context.eval("count_args(#{args})") == 33
+    RUBY
+  end
+
+  def test_callback_preserves_minus_zero_normalization
+    assert_single_threaded_script <<~'RUBY'
+      context = MiniRacer::Context.new
+      context.attach("describe", proc { |value| [value.class.name, 1.0 / value] })
+
+      raise "bad minus zero callback result" unless context.eval("describe(-0)") == ["Integer", Float::INFINITY]
+      raise "bad slow minus zero callback result" unless context.eval('describe(-0, "force slow path")') == ["Integer", Float::INFINITY]
+    RUBY
+  end
+
   def test_nested_javascript_ruby_javascript_call
     assert_single_threaded_script <<~'RUBY'
       context = MiniRacer::Context.new


### PR DESCRIPTION
New numbers post PR are: 

Default platform is now faster than v0.21.0 for these rows:

callback/1000_echo_int  v0.21.0 3.278 ms  working 2.449 ms
callback/1000_add_ints  v0.21.0 3.845 ms  working 2.567 ms


not sure if it is worth the complexity or not so will sit on it 
